### PR TITLE
Add Multi-Translation Audio Support

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -178,9 +178,7 @@ export const getBibleAudioUrl = async (
 ): Promise<string> => {
   try {
     const passage = `${book} ${chapter}`;
-    const url = `https://bible-research.vercel.app/api/v1/bible?response_format=audio&passage=${encodeURIComponent(
-      passage
-    )}`;
+    const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}&response_format=audio`;
 
     const response = await fetch(url, {
       method: 'GET',

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -196,6 +196,14 @@ export const getBibleAudioUrl = async (
     }
 
     const data: AudioResponse = await response.json();
+    
+    // Validate audio_url exists and is a string
+    if (!data.audio_url || typeof data.audio_url !== 'string') {
+      throw new Error(
+        `Invalid audio URL in API response for ${translation}: ${JSON.stringify(data)}`
+      );
+    }
+    
     return data.audio_url;
   } catch (error) {
     console.error(`Error fetching ${translation} audio:`, error);

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -195,12 +195,22 @@ export const getBibleAudioUrl = async (
       );
     }
 
-    const data: AudioResponse = await response.json();
+    const data: any = await response.json();
+    
+    // Check if API returned an error
+    if (data.error) {
+      const errorMsg = typeof data.error === 'string' 
+        ? data.error 
+        : data.error.message || 'Unknown error';
+      throw new Error(
+        `Audio not available for ${translation} ${book} ${chapter}: ${errorMsg}`
+      );
+    }
     
     // Validate audio_url exists and is a string
     if (!data.audio_url || typeof data.audio_url !== 'string') {
       throw new Error(
-        `Invalid audio URL in API response for ${translation}: ${JSON.stringify(data)}`
+        `No audio URL in API response for ${translation} ${book} ${chapter}`
       );
     }
     

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -82,9 +82,6 @@ export const getVersesInEsvChapter = async (
   try {
     const passage = `${thebook} ${thechapter}`;
     const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}`;
-    
-    console.log(`Fetching verses from: ${url}`);
-    
     const response = await fetch(url, {
       method: 'GET',
       headers: {
@@ -182,8 +179,6 @@ export const getBibleAudioUrl = async (
   try {
     const passage = `${book} ${chapter}`;
     const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}&response_format=audio`;
-    
-    console.log(`Fetching audio from: ${url}`);
 
     const response = await fetch(url, {
       method: 'GET',

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -82,6 +82,9 @@ export const getVersesInEsvChapter = async (
   try {
     const passage = `${thebook} ${thechapter}`;
     const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}`;
+    
+    console.log(`Fetching verses from: ${url}`);
+    
     const response = await fetch(url, {
       method: 'GET',
       headers: {
@@ -179,6 +182,8 @@ export const getBibleAudioUrl = async (
   try {
     const passage = `${book} ${chapter}`;
     const url = `https://bible-research.vercel.app/api/v1/bible?passage=${passage}&response_format=audio`;
+    
+    console.log(`Fetching audio from: ${url}`);
 
     const response = await fetch(url, {
       method: 'GET',

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -150,6 +150,78 @@ export const addTagNote = async (
   }
 };
 
+// ============================================
+// AUDIO FUNCTIONS
+// ============================================
+
+export interface AudioResponse {
+  book: string;
+  book_name: string;
+  chapter: number;
+  audio_url: string;
+  duration_seconds: number;
+  file_size_bytes: number;
+  format: string;
+}
+
+/**
+ * Get audio URL for any Bible translation from Bible Research API
+ * @param book - Book name (e.g., "Genesis", "2 Chronicles")
+ * @param chapter - Chapter number
+ * @param translation - Translation code (e.g., "ESV", "NIV", "NASB")
+ * @returns Audio URL string
+ */
+export const getBibleAudioUrl = async (
+  book: string,
+  chapter: number,
+  translation: string
+): Promise<string> => {
+  try {
+    const passage = `${book} ${chapter}`;
+    const url = `https://bible-research.vercel.app/api/v1/bible?response_format=audio&passage=${encodeURIComponent(
+      passage
+    )}`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch audio for ${translation}: ${response.statusText}`
+      );
+    }
+
+    const data: AudioResponse = await response.json();
+    return data.audio_url;
+  } catch (error) {
+    console.error(`Error fetching ${translation} audio:`, error);
+    throw error;
+  }
+};
+
+/**
+ * Get KJV audio URL from wordpocket.org
+ * @param book - Book name
+ * @param chapter - Chapter number
+ * @returns Audio URL string
+ */
+export const getKjvAudioUrl = (book: string, chapter: number): string => {
+  const books = getBooks();
+  const index = books.findIndex((b) => b.book_name === book);
+
+  if (index === -1) {
+    throw new Error(`Book not found: ${book}`);
+  }
+
+  return `https://wordpocket.org/bibles/app/audio/1/${
+    index + 1
+  }/${chapter}.mp3`;
+};
+
 export interface NoteVerse {
   book: string;
   chapter: number;

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -42,6 +42,18 @@ const Audio = () => {
             );
           }
 
+          // Validate audio URL
+          if (!audioUrl || typeof audioUrl !== 'string') {
+            throw new Error(
+              `Invalid audio URL: ${audioUrl} for ${bibleVersion}`
+            );
+          }
+
+          console.log(
+            `Playing audio: ${bibleVersion} ${activeBook} ${activeChapter}`
+          );
+          console.log(`Audio URL: ${audioUrl}`);
+
           // Create and play audio
           const audioHowl = new Howl({
             src: [audioUrl],

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -53,13 +53,13 @@ const Audio = () => {
             },
             onpause: () => setIsPlaying(false),
             onend: () => setIsPlaying(false),
-            onloaderror: (id, err) => {
+            onloaderror: (_id, err) => {
               console.error('Audio load error:', err);
               setError('Failed to load audio');
               setIsPlaying(false);
               setLoading(false);
             },
-            onplayerror: (id, err) => {
+            onplayerror: (_id, err) => {
               console.error('Audio play error:', err);
               setError('Failed to play audio');
               setIsPlaying(false);

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -83,7 +83,21 @@ const Audio = () => {
           audioHowl.play();
         } catch (err) {
           console.error('Error loading audio:', err);
-          setError(err instanceof Error ? err.message : 'Unknown error');
+          
+          // Extract user-friendly error message
+          let errorMsg = 'Audio unavailable';
+          if (err instanceof Error) {
+            // Extract just the key part of the error
+            if (err.message.includes('not available')) {
+              errorMsg = 'Audio not available';
+            } else if (err.message.includes('No Fileset')) {
+              errorMsg = 'Audio not available for this chapter';
+            } else {
+              errorMsg = err.message.split(':')[0]; // Get first part
+            }
+          }
+          
+          setError(errorMsg);
           setIsPlaying(false);
           setLoading(false);
         }

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -49,11 +49,6 @@ const Audio = () => {
             );
           }
 
-          console.log(
-            `Playing audio: ${bibleVersion} ${activeBook} ${activeChapter}`
-          );
-          console.log(`Audio URL: ${audioUrl}`);
-
           // Create and play audio
           const audioHowl = new Howl({
             src: [audioUrl],


### PR DESCRIPTION
## Summary
Extends audio playback functionality to support multiple Bible translations (currently only ESV, but with slight adjustments thousands of translations can be supported) beyond the existing KJV support. Audio for non-KJV translations is fetched from the Bible Research API, while KJV continues to use the existing wordpocket.org source.

## Changes

### API Layer (`src/api.tsx`)
- Added `AudioResponse` interface for Bible Research API audio responses
- Added `getBibleAudioUrl()` - Generic function to fetch audio URLs for any translation
- Added `getKjvAudioUrl()` - Extracted KJV audio URL logic into dedicated function
- Proper error handling and TypeScript typing

### Audio Component (`src/components/Audio.tsx`)
- Detects Bible version from store and routes to appropriate audio source
- KJV: Uses wordpocket.org (instant, no API call)
- Other translations: Fetches audio URL from Bible Research API
- Added loading state with spinner during URL fetch
- Added error handling for network failures and audio load/play errors
- Button disabled during loading with tooltip feedback
- Proper cleanup on component unmount

## Technical Details

### Audio URL Sources
- **KJV**: `https://wordpocket.org/bibles/app/audio/1/{book_index}/{chapter}.mp3`
- **ESV/Others**: `https://bible-research.vercel.app/api/v1/bible?response_format=audio&passage={book}%20{chapter}`

### API Response Format
```json
{
  "book": "GEN",
  "book_name": "Genesis",
  "chapter": 1,
  "audio_url": "https://...",
  "duration_seconds": 150,
  "file_size_bytes": 346163,
  "format": "audio"
}
```

## User Experience

### KJV Audio (unchanged)
1. User clicks play button
2. Audio starts immediately

### ESV/Other Translations (new)
1. User clicks play button
2. Loading spinner appears
3. Audio URL fetched from API
4. Audio starts playing
5. Stop button appears