### PR TITLE
Addressed bug with notes view not rendering multiple verses.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" /> <!-- Added base tag -->
     <title>Reactive Bible</title>
   </head>
   <body>

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -7,11 +7,11 @@ interface NoteCardProps {
   onViewInBible: (book: string, chapter: number, verse: number) => void;
 }
 
-const NoteCard = ({ note, onViewInBible }: NoteCardProps) => {
-  const firstVerse = note.verses[0]?.verse || 1;
-  const lastVerse = note.verses[note.verses.length - 1]?.verse || 1;
-  const book = note.verses[0]?.book || "";
-  const chapter = note.verses[0]?.chapter || 1;
+const NoteCard = ({ note, onViewInBible }: NoteCardProps) => {  
+  const firstVerse = note?.verses?.[0]?.verse || 1;
+  const lastVerse = note?.verses?.[note.verses.length - 1]?.verse || 1;
+  const book = note?.verses?.[0]?.book || "";
+  const chapter = note?.verses?.[0]?.chapter || 1;
 
   const heading =
     firstVerse === lastVerse
@@ -31,7 +31,7 @@ const NoteCard = ({ note, onViewInBible }: NoteCardProps) => {
         </Button>
       </Group>
 
-      {note.verses.map((v) => (
+      {note?.verses?.map(v => (
         <Verse key={v.verse} verse={v.verse} text={v.text} />
       ))}
 

--- a/src/components/NotesView.tsx
+++ b/src/components/NotesView.tsx
@@ -21,7 +21,7 @@ const NotesView = ({ onViewInBible }: NotesViewProps) => {
         "https://bible-research.vercel.app/api/v1/tags/"
       );
       const data = await response.json();
-      const fetchedTags = data.map((item: { id: any; name: any; }, index: any) => ({
+      const fetchedTags = data.map((item: { id: any; name: any; }, index: number) => ({
         id: item.id,
         name: item.name,
         key: index,
@@ -32,7 +32,7 @@ const NotesView = ({ onViewInBible }: NotesViewProps) => {
       if (fetchedTags.length > 0 && !selectedTagId) {
         setSelectedTagId(fetchedTags[0].id);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error fetching tags:', error);
     }
   };
@@ -107,7 +107,7 @@ const NotesView = ({ onViewInBible }: NotesViewProps) => {
 
   // Group notes by tag name
   const groupedNotes = notes.reduce((acc, note) => {
-    const tagName = note.tag.name;
+    const tagName = note.tag?.name ?? 'Untagged';
     if (!acc[tagName]) {
       acc[tagName] = [];
     }


### PR DESCRIPTION
Context:
When viewing notes, it has been observed that a bug occures when retrieving notes for a tag under which there are a lot of passages.

Problem:
Usually when trying to access items in an array or object which could possibly be undefined or null in JavaScript runtime we would get an error. 

Solution:
This is where optional chaining would be an appropriate fix.