### PR TITLE
Improve Notes view UI layout and spacing

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -23,17 +23,17 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
       : `${book} ${chapter}:${firstVerse}-${lastVerse}`;
 
   return (
-    <Card shadow="sm" padding={0} radius="md" mb={15}>
-      <Group position="apart" mb={10}>
+    <Card shadow="sm" padding="sm" radius="md" mb={15}>
+      <Group position="apart" mb={0}>
         <Title order={4}>{heading}</Title>
-        <Button
-          variant="subtle"
-          size="xs"
-          onClick={() => onViewInBible(book, chapter, firstVerse)}
-        >
-          View in Bible
-        </Button>
-        <Group>
+        <Group spacing="xs">
+          <Button
+            variant="subtle"
+            size="xs"
+            onClick={() => onViewInBible(book, chapter, firstVerse)}
+          >
+            View in Bible
+          </Button>
           <Button
             variant="subtle"
             size="xs"
@@ -54,9 +54,11 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
         </Group>
       </Group>
 
-      {note?.verses?.map(v => (
-        <Verse key={v.verse} verse={v.verse} text={v.text} />
-      ))}
+      <Box mt={-10}>
+        {note?.verses?.map(v => (
+          <Verse key={v.verse} verse={v.verse} text={v.text} />
+        ))}
+      </Box>
 
       <Box
         mt={10}

--- a/src/components/NotesView.tsx
+++ b/src/components/NotesView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import type { MouseEvent } from "react";
-import { ScrollArea, Select, Group, Stack, Center, Text, Loader } from "@mantine/core";
+import { ScrollArea, Select, Group, Stack, Center, Text, Loader, Box } from "@mantine/core";
 import { Note, Tag } from "../types";
 import TagSection from "./TagSection";
 import EditNoteModal from "./EditNoteModal";
@@ -102,24 +102,28 @@ const NotesView = ({ onViewInBible }: NotesViewProps) => {
 
     return (
     <>
-      <ScrollArea style={{ height: 'calc(100vh - 220px)' }}>
-        <Stack spacing="md" p="md">
-          <Group>
-            <Select
-              label="Filter by tag"
-              placeholder="Select a tag"
-              value={selectedTagId}
-              onChange={handleTagChange}
-              data={sortedTags.map(tag => ({ value: tag.id, label: tag.name }))}
-              searchable
-            />
-            <Button onClick={handleRefresh}>Refresh Notes</Button>
-          </Group>
-
-          {loading ? (
-            <Center style={{ height: 200 }}><Loader aria-label="loading" /></Center>
-          ) : notesByTag.length > 0 ? (
-            notesByTag.map(({ tag, notes }) => (
+      <Box mb="md">
+        <Group align="flex-end" spacing="xs">
+          <Select
+            label="Filter by tag"
+            placeholder="Select a tag"
+            value={selectedTagId}
+            onChange={handleTagChange}
+            data={sortedTags.map(tag => ({ value: tag.id, label: tag.name }))}
+            searchable
+            style={{ flex: 1, minWidth: 200 }}
+          />
+          <Button onClick={handleRefresh} size="xs">
+            Refresh
+          </Button>
+        </Group>
+      </Box>
+      <ScrollArea style={{ height: 'calc(100vh - 280px)' }}>
+        {loading ? (
+          <Center style={{ height: 200 }}><Loader aria-label="loading" /></Center>
+        ) : notesByTag.length > 0 ? (
+          <Stack spacing="md">
+            {notesByTag.map(({ tag, notes }) => (
               <TagSection
                 key={tag.id}
                 tagName={tag.name}
@@ -128,11 +132,11 @@ const NotesView = ({ onViewInBible }: NotesViewProps) => {
                 onEditNote={handleEditNote}
                 onDeleteNote={handleDeleteNote}
               />
-            ))
-          ) : (
-            <Center style={{ height: 200 }}><Text>No notes found.</Text></Center>
-          )}
-        </Stack>
+            ))}
+          </Stack>
+        ) : (
+          <Center style={{ height: 200 }}><Text>No notes found.</Text></Center>
+        )}
       </ScrollArea>
       <EditNoteModal
         opened={isEditModalOpen}

--- a/src/components/Passage.tsx
+++ b/src/components/Passage.tsx
@@ -40,14 +40,7 @@ const Passage = ({ open }: { open: () => void }) => {
         showNotes={showNotes}
         setShowNotes={setShowNotes}
       />
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-        h="80vh"
-      >
+      <Box h="80vh">
         {showNotes ? (
           <NotesView onViewInBible={handleViewInBible} />
         ) : (


### PR DESCRIPTION
## Changes

This PR improves the Notes view UI to provide better layout consistency and spacing:

### Layout Improvements
- **Full-width Bible passages**: Made Bible passages in Notes view as wide as in Bible view by removing padding constraints and centering styles.
- **Better button alignment**: Grouped all action buttons (View in Bible, Edit, Remove) together on the right side with consistent spacing.
- **Compact controls**: Reduced filter control sizes and improved alignment with  for better visual consistency.

### Spacing Optimizations
- **Reduced heading-to-verse gap**: Optimized spacing between note headings and verse content using negative margins.
- **Tighter button spacing**: Changed button group spacing to  for a more compact layout.
- **Smaller button sizes**: Changed the Refresh button to  to take up less space.

### Technical Details
- Modified : Restructured layout to move filter controls outside ScrollArea, improved alignment.
- Modified : Added Card padding, wrapped verses in a Box with a negative margin, and grouped buttons.
- Modified : Removed flex centering constraints to allow full-width content.

### Visual Result
- Notes view now has the same visual width as the Bible view.
- The interface is cleaner and more compact.
- Better use of available screen space.
- Improved visual hierarchy.

## Testing
- ✅ Tested in browser preview.
- ✅ Verified button alignment and spacing.
- ✅ Confirmed full-width layout matches the Bible view.
- ✅ Checked responsive behavior.