### PR TITLE
fix(tags): scrollable Tag Management page

### DIFF
--- a/src/routes/TagManagementRoute.tsx
+++ b/src/routes/TagManagementRoute.tsx
@@ -6,6 +6,7 @@ import {
   Center,
   Group,
   Loader,
+  ScrollArea,
   Stack,
   Text,
   TextInput,
@@ -101,7 +102,15 @@ export default function TagManagementRoute() {
   }
 
   return (
-    <Box p="md">
+    <Box
+      p="md"
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+      }}
+    >
       <Group position="apart" mb="lg">
         <Title order={2}>Tag Management</Title>
         <Button
@@ -122,7 +131,7 @@ export default function TagManagementRoute() {
       />
 
       {filteredTags.length === 0 ? (
-        <Center style={{ height: 200 }}>
+        <Center style={{ flex: 1, minHeight: 0 }}>
           <Stack align="center" spacing="xs">
             <Text color="dimmed">
               {searchQuery
@@ -141,17 +150,20 @@ export default function TagManagementRoute() {
           </Stack>
         </Center>
       ) : (
-        <Text color="dimmed" size="sm" mb="md">
-          {filteredTags.length} {filteredTags.length === 1 ? 'tag' : 'tags'}
-        </Text>
+        <>
+          <Text color="dimmed" size="sm" mb="md">
+            {filteredTags.length} {filteredTags.length === 1 ? 'tag' : 'tags'}
+          </Text>
+          <ScrollArea style={{ flex: 1, minHeight: 0 }} type="auto">
+            <TagTree
+              tags={filteredTags}
+              onEdit={handleEditTag}
+              onDelete={handleDeleteTag}
+              onViewNotes={handleViewNotes}
+            />
+          </ScrollArea>
+        </>
       )}
-
-      <TagTree
-        tags={filteredTags}
-        onEdit={handleEditTag}
-        onDelete={handleDeleteTag}
-        onViewNotes={handleViewNotes}
-      />
 
       <CreateTagModal
         opened={createModalOpen}


### PR DESCRIPTION
## Summary

The `/tags` route renders inside `AppShell` `main`, which uses `overflow: hidden` and a fixed viewport height. The tag list had no inner scroll container, so long tag trees were clipped with no way to scroll.

## Changes

- Wrap the tag tree in Mantine `ScrollArea` when there are tags to show.
- Use a flex column layout on the route root (`height: 100%`, `minHeight: 0`) so the scroll region fills the space below the pinned header, search field, and count line.
- Keep the empty state in a flex-growing `Center` when there are no tags (no empty `ScrollArea`).

## Testing

- `npm run build` passes.
- Manually verify `/tags` with many tags or expanded nested tags.

Made with [Cursor](https://cursor.com)