### PR TITLE
feat: support public sharing of notes by tag_id and note_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # Bible Research API Base URL
-VITE_API_BASE_URL=https://bibleresearchapi.vercel.app
+VITE_API_BASE_URL=https://bible-research-489314.ey.r.appspot.com

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Local env files
+.env
+.env.local
+.env.*.local
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/__tests__/helpers/factories.ts
+++ b/src/__tests__/helpers/factories.ts
@@ -45,6 +45,7 @@ export const createMockNote = (overrides: Partial<Note> = {}): Note => ({
   note_text: 'Test note',
   tag: createMockTag(),
   public: false,
+  is_owner: true,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
   verses: [],

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -9,7 +9,8 @@ import {
   getCachedTranslations,
   cacheTranslations,
 } from './utils/cacheManager';
-import { authenticatedFetch } from './utils/apiClient';
+import { authenticatedFetch, publicFetch } from './utils/apiClient';
+import { API_BASE_URL } from './config';
 
 export const data = bibleJson as KjvBook[];
 
@@ -131,7 +132,7 @@ export const addTagNote = async (
   });
   try {
     const response = await authenticatedFetch(
-      'https://bibleresearchapi.vercel.app/api/v1/notes/', 
+      `${API_BASE_URL}/api/v1/notes/`,
       {
         method: 'POST',
         body: body,
@@ -155,7 +156,7 @@ export const editNote = async (
   const body = JSON.stringify({ tag: tagId, note_text: noteText });
   try {
     const response = await authenticatedFetch(
-      `https://bibleresearchapi.vercel.app/api/v1/notes/${noteId}/`, 
+      `${API_BASE_URL}/api/v1/notes/${noteId}/`,
       {
         method: 'PATCH',
         body: body,
@@ -174,7 +175,7 @@ export const editNote = async (
 export const deleteNote = async (noteId: string) => {
   try {
     const response = await authenticatedFetch(
-      `https://bibleresearchapi.vercel.app/api/v1/notes/${noteId}`, 
+      `${API_BASE_URL}/api/v1/notes/${noteId}/`,
       {
         method: 'DELETE',
       }
@@ -193,7 +194,7 @@ export const deleteNote = async (noteId: string) => {
 export const getTags = async (): Promise<Tag[]> => {
   try {
     const response = await authenticatedFetch(
-      'https://bibleresearchapi.vercel.app/api/v1/tags/'
+      `${API_BASE_URL}/api/v1/tags/`
     );
     if (!response.ok) {
       throw new Error('Failed to fetch tags');
@@ -207,8 +208,8 @@ export const getTags = async (): Promise<Tag[]> => {
 
 export const getTag = async (tagId: string): Promise<Tag> => {
   try {
-    const response = await authenticatedFetch(
-      `https://bibleresearchapi.vercel.app/api/v1/tags/${tagId}/`
+    const response = await publicFetch(
+      `${API_BASE_URL}/api/v1/tags/${tagId}/`
     );
     if (!response.ok) {
       throw new Error('Failed to fetch tag');
@@ -230,7 +231,7 @@ export const createTag = async (
   });
   try {
     const response = await authenticatedFetch(
-      'https://bibleresearchapi.vercel.app/api/v1/tags/',
+      `${API_BASE_URL}/api/v1/tags/`,
       {
         method: 'POST',
         body: body,
@@ -257,7 +258,7 @@ export const updateTag = async (
   });
   try {
     const response = await authenticatedFetch(
-      `https://bibleresearchapi.vercel.app/api/v1/tags/${tagId}/`,
+      `${API_BASE_URL}/api/v1/tags/${tagId}/`,
       {
         method: 'PATCH',
         body: body,
@@ -276,7 +277,7 @@ export const updateTag = async (
 export const deleteTag = async (tagId: string): Promise<void> => {
   try {
     const response = await authenticatedFetch(
-      `https://bibleresearchapi.vercel.app/api/v1/tags/${tagId}/`,
+      `${API_BASE_URL}/api/v1/tags/${tagId}/`,
       {
         method: 'DELETE',
       }
@@ -571,6 +572,7 @@ export interface Note {
   id: string;
   note_text: string;
   public: boolean;
+  is_owner: boolean;
   created_at: string;
   updated_at: string;
   tag: Tag;
@@ -579,16 +581,31 @@ export interface Note {
 
 export const getNotes = async (tagId?: string): Promise<Note[]> => {
   const url = tagId
-    ? `https://bibleresearchapi.vercel.app/api/v1/notes/?tag_id=${tagId}`
-    : 'https://bibleresearchapi.vercel.app/api/v1/notes/';
+    ? `${API_BASE_URL}/api/v1/notes/?tag_id=${tagId}`
+    : `${API_BASE_URL}/api/v1/notes/`;
   try {
-    const response = await authenticatedFetch(url);
+    const response = await publicFetch(url);
     if (!response.ok) {
       throw new Error('Failed to fetch notes');
     }
     return await response.json();
   } catch (error) {
     console.error('Error fetching notes:', error);
+    throw error;
+  }
+};
+
+export const getNote = async (noteId: string): Promise<Note> => {
+  try {
+    const response = await publicFetch(
+      `${API_BASE_URL}/api/v1/notes/${noteId}/`
+    );
+    if (!response.ok) {
+      throw new Error('Failed to fetch note');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching note:', error);
     throw error;
   }
 };

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -7,8 +7,8 @@ import Button from "./Button";
 interface NoteCardProps {
   note: Note;
   onViewInBible: (book: string, chapter: number, verse: number) => void;
-  onEdit: (note: Note) => void;
-  onDelete: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
+  onEdit?: (note: Note) => void;
+  onDelete?: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
 }
 
 const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {  
@@ -22,6 +22,9 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
       ? `${book} ${chapter}:${firstVerse}`
       : `${book} ${chapter}:${firstVerse}-${lastVerse}`;
 
+  const canEdit = note.is_owner && !!onEdit;
+  const canDelete = note.is_owner && !!onDelete;
+
   return (
     <Card shadow="sm" padding="sm" radius="md" mb={15}>
       <Group position="apart" mb={0}>
@@ -34,23 +37,27 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
           >
             View in Bible
           </Button>
-          <Button
-            variant="subtle"
-            size="xs"
-            onClick={() => onEdit(note)}
-          >
-            Edit
-          </Button>
-          <Button
-            variant="subtle"
-            size="xs"
-            onClick={
-              (evt: MouseEvent<HTMLButtonElement>) => 
-                onDelete(evt, note)
-            }
-          >
-            Remove
-          </Button>
+          {canEdit && (
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={() => onEdit!(note)}
+            >
+              Edit
+            </Button>
+          )}
+          {canDelete && (
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={
+                (evt: MouseEvent<HTMLButtonElement>) =>
+                  onDelete!(evt, note)
+              }
+            >
+              Remove
+            </Button>
+          )}
         </Group>
       </Group>
 

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent } from "react";
 import { Card, Title, Text, Group, Box } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
 import { Note } from "../types";
 import Verse from "./Verse";
 import Button from "./Button";
@@ -24,6 +25,38 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
 
   const canEdit = note.is_owner && !!onEdit;
   const canDelete = note.is_owner && !!onDelete;
+  const canShare = note.public;
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/notes/${note.id}`;
+    const title = note.tag?.name
+      ? `Note: ${note.tag.name}`
+      : 'Shared note';
+    const text = note.note_text
+      ? note.note_text.slice(0, 140)
+      : 'Shared Bible note';
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+        return;
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        console.error('Error sharing:', err);
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showNotification({
+        title: 'Link Copied!',
+        message: 'Note link copied to clipboard',
+        color: 'blue',
+      });
+    } catch (err) {
+      console.error('Error copying to clipboard:', err);
+    }
+  };
 
   return (
     <Card shadow="sm" padding="sm" radius="md" mb={15}>
@@ -37,6 +70,15 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
           >
             View in Bible
           </Button>
+          {canShare && (
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={handleShare}
+            >
+              Share
+            </Button>
+          )}
           {canEdit && (
             <Button
               variant="subtle"

--- a/src/components/TagSection.tsx
+++ b/src/components/TagSection.tsx
@@ -7,8 +7,8 @@ interface TagSectionProps {
   tagName: string;
   notes: Note[];
   onViewInBible: (book: string, chapter: number, verse: number) => void;
-  onEditNote: (note: Note) => void;
-  onDeleteNote: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
+  onEditNote?: (note: Note) => void;
+  onDeleteNote?: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
 }
 
 const TagSection = ({ tagName, notes, onViewInBible, onEditNote, onDeleteNote }: TagSectionProps) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,7 @@
+/**
+ * Runtime configuration resolved from Vite env vars.
+ * VITE_API_BASE_URL overrides the default in development via a local `.env`.
+ */
+export const API_BASE_URL: string =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '')
+  || 'https://bibleresearchapi.vercel.app';

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,4 +4,4 @@
  */
 export const API_BASE_URL: string =
   (import.meta.env.VITE_API_BASE_URL as string | undefined)?.replace(/\/$/, '')
-  || 'https://bibleresearchapi.vercel.app';
+  || 'https://bible-research-489314.ey.r.appspot.com';

--- a/src/routes/NoteDetailRoute.tsx
+++ b/src/routes/NoteDetailRoute.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Center,
+  Loader,
+  Stack,
+  Text,
+  Group,
+  ActionIcon,
+  Tooltip,
+} from '@mantine/core';
+import { IconShare } from '@tabler/icons-react';
+import { showNotification } from '@mantine/notifications';
+import { Note } from '../types';
+import NoteCard from '../components/NoteCard';
+import { getNote } from '../api';
+import { useBibleStore } from '../store';
+
+/**
+ * Public single-note page reachable via `/notes/:noteId`. Works for any
+ * visitor when the note is `public=true`; a private note returns 404
+ * from the backend and surfaces a friendly error.
+ */
+export default function NoteDetailRoute() {
+  const { noteId } = useParams<{ noteId: string }>();
+  const navigate = useNavigate();
+
+  const setActiveBook = useBibleStore((state) => state.setActiveBook);
+  const setActiveChapter = useBibleStore((state) => state.setActiveChapter);
+  const setActiveVerses = useBibleStore((state) => state.setActiveVerses);
+  const setShowNotes = useBibleStore((state) => state.setShowNotes);
+
+  const [note, setNote] = useState<Note | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      if (!noteId) {
+        setError('No note ID provided');
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const fetched = await getNote(noteId);
+        if (cancelled) return;
+        setNote(fetched);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Error loading note:', err);
+        setError('Note not found or is not public.');
+        setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [noteId]);
+
+  const handleViewInBible = (
+    book: string,
+    chapter: number,
+    verse: number,
+  ) => {
+    setActiveBook(book);
+    setActiveChapter(chapter);
+    setActiveVerses([verse]);
+    navigate(`/bible/${book}/${chapter}`);
+    setShowNotes(false);
+  };
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    const title = note?.tag?.name
+      ? `Note: ${note.tag.name}`
+      : 'Shared note';
+    const text = note?.note_text
+      ? note.note_text.slice(0, 140)
+      : 'Shared Bible note';
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          console.error('Error sharing:', err);
+        }
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showNotification({
+        title: 'Link Copied!',
+        message: 'Note link copied to clipboard',
+        color: 'blue',
+      });
+    } catch (err) {
+      console.error('Error copying to clipboard:', err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Loader size="lg" aria-label="loading" />
+      </Center>
+    );
+  }
+
+  if (error || !note) {
+    return (
+      <Center style={{ height: '100vh' }}>
+        <Text color="red" size="lg">
+          {error || 'Note not found.'}
+        </Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Box p="md">
+      <Group position="apart" mb="md">
+        <Text fw={500} size="lg">
+          {note.tag?.name || 'Shared note'}
+        </Text>
+        <Tooltip label="Share note link" position="left">
+          <ActionIcon
+            onClick={handleShare}
+            variant="subtle"
+            color="blue"
+            size="lg"
+          >
+            <IconShare size={20} />
+          </ActionIcon>
+        </Tooltip>
+      </Group>
+
+      <Stack spacing="md">
+        <NoteCard
+          note={note}
+          onViewInBible={handleViewInBible}
+        />
+      </Stack>
+    </Box>
+  );
+}

--- a/src/routes/NotesRoute.tsx
+++ b/src/routes/NotesRoute.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Center, Loader } from '@mantine/core';
 import { useBibleStore } from '../store';
+import { useAuthStore } from '../stores/authStore';
 
 export default function NotesRoute() {
   const navigate = useNavigate();
@@ -10,10 +11,20 @@ export default function NotesRoute() {
     lastSelectedTagId: state.lastSelectedTagId,
     getTags: state.getTags,
   }));
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   useEffect(() => {
     // Prevent double-navigation in React Strict Mode
     if (hasNavigatedRef.current) return;
+
+    // Anonymous visitors have no "default tag" to land on and no way to
+    // browse tags. Send them to the bible page; direct share links to
+    // /notes/:noteId or /notes/tag/:tagId still work for them.
+    if (!isAuthenticated) {
+      hasNavigatedRef.current = true;
+      navigate('/bible', { replace: true });
+      return;
+    }
 
     const navigateToTag = async () => {
       try {

--- a/src/routes/TagNotesRoute.tsx
+++ b/src/routes/TagNotesRoute.tsx
@@ -19,7 +19,8 @@ import { Note, Tag } from '../types';
 import TagSection from '../components/TagSection';
 import EditNoteModal from '../components/EditNoteModal';
 import { useBibleStore } from '../store';
-import { deleteNote } from '../api';
+import { deleteNote, getTag } from '../api';
+import { useAuthStore } from '../stores/authStore';
 import { clearNotesCache } from '../utils/cacheManager';
 
 export default function TagNotesRoute() {
@@ -40,6 +41,7 @@ export default function TagNotesRoute() {
   const setLastSelectedTagId = useBibleStore(
     (state) => state.setLastSelectedTagId
   );
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   
   const [tag, setTag] = useState<Tag | null>(null);
   const [loading, setLoading] = useState(true);
@@ -55,35 +57,48 @@ export default function TagNotesRoute() {
 
   useEffect(() => {
     let cancelled = false;
-    
+
     const loadTagAndNotes = async () => {
       if (!tagId) {
         setError('No tag ID provided');
         setLoading(false);
         return;
       }
-      
+
       setLoading(true);
       setError(null);
 
       try {
-        await getTags();
-        
-        const currentTag = storedTags.find(t => t.id === tagId);
-        
-        if (!currentTag) {
-          if (cancelled) return;
-          setError(`Tag not found: ${tagId}`);
-          setLoading(false);
-          return;
+        // Preload the caller's own tags when authenticated so the tag
+        // switcher works. Failures are non-fatal for shared pages.
+        if (isAuthenticated) {
+          try { await getTags(); } catch { /* ignore */ }
         }
 
-        setTag(currentTag);
-        
         await fetchNotes(tagId);
-        
         if (cancelled) return;
-        // Successfully loaded, clear loading state
+
+        const fetchedNotes = useBibleStore.getState().notes;
+        let resolvedTag: Tag | null =
+          useBibleStore.getState().tags.find((t) => t.id === tagId) ||
+          fetchedNotes[0]?.tag ||
+          null;
+
+        if (!resolvedTag) {
+          try {
+            resolvedTag = await getTag(tagId);
+          } catch {
+            resolvedTag = null;
+          }
+        }
+
+        if (cancelled) return;
+
+        if (!resolvedTag) {
+          setError('No public notes available for this tag.');
+        } else {
+          setTag(resolvedTag);
+        }
         setLoading(false);
       } catch (err) {
         if (cancelled) return;
@@ -94,11 +109,11 @@ export default function TagNotesRoute() {
     };
 
     loadTagAndNotes();
-    
+
     return () => {
       cancelled = true;
     };
-  }, [tagId, storedTags, fetchNotes, getTags]);
+  }, [tagId, fetchNotes, getTags, isAuthenticated]);
 
   const handleEditNote = (note: Note) => {
     setNoteToEdit(note);
@@ -237,15 +252,19 @@ export default function TagNotesRoute() {
   return (
     <Box p="md">
       <Group mb="md" position="apart">
-        <Select
-          label="Filter by tag"
-          placeholder="Select a tag"
-          value={tagId}
-          onChange={handleTagChange}
-          data={sortedTags.map(t => ({ value: t.id, label: t.name }))}
-          searchable
-          style={{ flex: 1, minWidth: 200, maxWidth: 400 }}
-        />
+        {isAuthenticated && sortedTags.length > 0 ? (
+          <Select
+            label="Filter by tag"
+            placeholder="Select a tag"
+            value={tagId}
+            onChange={handleTagChange}
+            data={sortedTags.map(t => ({ value: t.id, label: t.name }))}
+            searchable
+            style={{ flex: 1, minWidth: 200, maxWidth: 400 }}
+          />
+        ) : (
+          <Text fw={500} size="lg">{tag.name}</Text>
+        )}
         <Group spacing="xs">
           <Text color="dimmed" size="sm">
             {notes.length} {notes.length === 1 ? 'note' : 'notes'}
@@ -280,8 +299,8 @@ export default function TagNotesRoute() {
               tagName={tag.name}
               notes={notes}
               onViewInBible={handleViewInBible}
-              onEditNote={handleEditNote}
-              onDeleteNote={handleDeleteNote}
+              onEditNote={isAuthenticated ? handleEditNote : undefined}
+              onDeleteNote={isAuthenticated ? handleDeleteNote : undefined}
             />
           </Stack>
         ) : (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import BibleRoute from './BibleRoute';
 import NotesRoute from './NotesRoute';
 import TagNotesRoute from './TagNotesRoute';
+import NoteDetailRoute from './NoteDetailRoute';
 import TagManagementRoute from './TagManagementRoute';
 import { LoginPage } from '../components/LoginPage';
 import { RegisterPage } from '../components/RegisterPage';
@@ -21,6 +22,7 @@ export function AppRoutes() {
       {/* Notes routes - public for viewing, protected for private notes */}
       <Route path="/notes" element={<NotesRoute />} />
       <Route path="/notes/tag/:tagId" element={<TagNotesRoute />} />
+      <Route path="/notes/:noteId" element={<NoteDetailRoute />} />
 
       {/* Tag management route */}
       <Route path="/tags" element={<TagManagementRoute />} />

--- a/src/stores/authStore.tsx
+++ b/src/stores/authStore.tsx
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { API_BASE_URL } from '../config';
 
 interface User {
   username: string;
@@ -26,8 +27,6 @@ export interface AuthState {
   setToken: (token: string, username: string) => void;
   checkAuth: () => void;
 }
-
-const API_BASE_URL = 'https://bibleresearchapi.vercel.app';
 
 export const initialState = {
   token: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Note {
   id: string;
   note_text: string;
   public: boolean;
+  is_owner: boolean;
   created_at: string;
   updated_at: string;
   tag: Tag;

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -20,6 +20,41 @@ const getAuthHeaders = (): HeadersInit => {
 };
 
 /**
+ * Public fetch wrapper
+ * Sends the auth token if one is present but never logs the user out on
+ * 401. Use for public-read endpoints (notes/tags list, detail, single
+ * note share page) where a stray 401 should never destroy an existing
+ * session.
+ *
+ * @param url - The URL to fetch
+ * @param options - Fetch options
+ * @param retries - Number of retries for network errors (default: 1)
+ */
+export const publicFetch = async (
+  url: string,
+  options: RequestInit = {},
+  retries = 1
+): Promise<Response> => {
+  const headers = getAuthHeaders();
+
+  try {
+    return await fetch(url, {
+      ...options,
+      headers: {
+        ...headers,
+        ...options.headers,
+      },
+    });
+  } catch (error) {
+    if (retries > 0 && error instanceof TypeError) {
+      console.warn('Network error (publicFetch), retrying...', error);
+      return publicFetch(url, options, retries - 1);
+    }
+    throw error;
+  }
+};
+
+/**
  * Authenticated fetch wrapper
  * Automatically adds auth token to requests and handles 401 responses
  * 


### PR DESCRIPTION
## Summary
Implements the frontend side of public note sharing tracked in #33.
Anyone (authenticated or not) can now open a `/notes/tag/:tagId` or
`/notes/:noteId` link and see the public notes, while owners keep their
full edit/delete experience.

Requires the backend PR: Bible-Research/bible-research#10.

## What changed
- **`src/config.ts`** — single source of truth for the API base URL.
  Reads `VITE_API_BASE_URL` first, falls back to the production App
  Engine URL
  `https://bible-research-489314.ey.r.appspot.com`. Every hardcoded
  `bibleresearchapi.vercel.app` in `src/api.tsx` and
  `src/stores/authStore.tsx` is gone. `.env` is gitignored and
  `.env.example` shows the default.
- **`publicFetch` helper** in `src/utils/apiClient.ts` — sends the token
  if present but, unlike `authenticatedFetch`, never logs the user out
  on 401. Used by `getNotes`, `getTag`, and the new `getNote`.
- **`Note.is_owner`** in `src/types.ts` + `src/api.tsx`. `NoteCard`
  renders Edit / Delete only when `is_owner && handler`; `onEdit` and
  `onDelete` are now optional. `NoteCard` also shows a Share button on
  `note.public` that copies `/notes/:id` (or fires the Web Share sheet
  on supported platforms).
- **`TagNotesRoute`** no longer gates on the tag being in `storedTags`
  (which only populates for authenticated owners). It fetches notes
  first, resolves the tag from `notes[0].tag` or `getTag(tagId)`, and
  hides the "Filter by tag" `Select` + edit/delete handlers when the
  visitor is unauthenticated.
- **`NoteDetailRoute`** at `/notes/:noteId` fetches a single note via
  `getNote`, rendering a share-friendly detail view. Invalid/private
  note ids surface a friendly "Note not found or is not public" state.
- **`NotesRoute`** redirects anonymous visitors to `/bible`. Direct
  share links bypass this route.
- **Rebased on latest main** — picks up #32's Vitest 1.6 upgrade and
  memory fixes.

## Test plan
- [ ] `npm run build` (and `tsc --noEmit`) — both clean locally.
- [ ] `VITE_API_BASE_URL=http://localhost:8000 npm run dev` against a
  local backend (or the App Engine prod URL).
- [ ] Sign out and hit `/notes/tag/<id>` / `/notes/<id>` — public notes
  render without Edit/Delete; private notes show the not-found state.
- [ ] Sign in as the owner — Edit / Delete buttons are back on own
  notes, hidden on other users' public notes.
- [ ] Click Share on a public note — link copied (or native share
  sheet) and opening that link works for a signed-out viewer.

Closes #33
Depends on Bible-Research/bible-research#10

Made with [Cursor](https://cursor.com)