### PR TITLE
fix: restore Edit/Delete buttons for authenticated users' notes

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -23,8 +23,8 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
       ? `${book} ${chapter}:${firstVerse}`
       : `${book} ${chapter}:${firstVerse}-${lastVerse}`;
 
-  const canEdit = note.is_owner && !!onEdit;
-  const canDelete = note.is_owner && !!onDelete;
+  const canEdit = (note.is_owner !== false) && !!onEdit;
+  const canDelete = (note.is_owner !== false) && !!onDelete;
   const canShare = note.public;
 
   const handleShare = async () => {


### PR DESCRIPTION
## Problem

Commit 555c0b9 (feat: support public sharing of notes) made Edit/Delete buttons conditional on `note.is_owner === true`. When the backend API doesn't return the `is_owner` field (`undefined`), the buttons disappear even for authenticated users viewing their own notes.

## Fix

Changed the condition in `NoteCard.tsx` from:
```ts
const canEdit = note.is_owner && !!onEdit;
const canDelete = note.is_owner && !!onDelete;
```
to:
```ts
const canEdit = (note.is_owner !== false) && !!onEdit;
const canDelete = (note.is_owner !== false) && !!onDelete;
```

This treats `is_owner !== false` (i.e. `true` or `undefined`) as owner, providing backward compatibility with backends that don't yet return `is_owner`. Public/shared notes viewed by non-owners still correctly hide the buttons (backend returns `is_owner: false`).

## Testing
- TagSection tests pass
- Authenticated users see Edit/Del
Commit 555c0b9 (feat: support public sharing of notes) made Edit/Delete buttons conditional on `note.ins