### PR TITLE
feat: Add audio verse highlighting during playback

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -1,5 +1,6 @@
 import bibleJson from "./assets/kjv.json";
 import { Translation } from "./store";
+import { VerseTimestamp } from './types';
 
 import {
   getCachedVerses,
@@ -8,6 +9,8 @@ import {
   cacheAudioUrl,
   getCachedTranslations,
   cacheTranslations,
+  getCachedTimestamps,
+  cacheTimestamps,
 } from './utils/cacheManager';
 import { authenticatedFetch, publicFetch } from './utils/apiClient';
 import { API_BASE_URL } from './config';
@@ -550,6 +553,42 @@ export const prefetchAdjacentChapters = async (
   }
   if (next) {
     prefetch(next.book, next.chapter, filesetId, 'next');
+  }
+};
+
+// ============================================
+// AUDIO TIMESTAMP FUNCTIONS
+// ============================================
+
+export const getAudioTimestamps = async (
+  book: string,
+  chapter: number,
+  filesetId: string
+): Promise<VerseTimestamp[]> => {
+  const cached = getCachedTimestamps(filesetId, book, chapter);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const url =
+      `${API_BASE_URL}/api/v1/bible/timestamps/` +
+      `?fileset_id=${encodeURIComponent(filesetId)}` +
+      `&book=${encodeURIComponent(book)}` +
+      `&chapter=${chapter}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Timestamps fetch failed: ${response.statusText}`
+      );
+    }
+    const data = await response.json();
+    const timestamps: VerseTimestamp[] = data.data || [];
+    cacheTimestamps(filesetId, book, chapter, timestamps);
+    return timestamps;
+  } catch (error) {
+    console.warn('Failed to fetch audio timestamps:', error);
+    return []; // Graceful degradation: no highlighting
   }
 };
 

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -583,7 +583,12 @@ export const getAudioTimestamps = async (
       );
     }
     const data = await response.json();
-    const timestamps: VerseTimestamp[] = data.data || [];
+    const timestamps: VerseTimestamp[] = (data.data || []).map(
+      (item: { verse_start: string | number; timestamp: number }) => ({
+        verse_start: Number(item.verse_start),
+        timestamp: item.timestamp,
+      })
+    );
     cacheTimestamps(filesetId, book, chapter, timestamps);
     return timestamps;
   } catch (error) {

--- a/src/components/Audio.test.tsx
+++ b/src/components/Audio.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../api', () => ({
     book: 'Genesis',
     chapter: 1,
   }),
+  getAudioTimestamps: vi.fn().mockResolvedValue([]),
 }));
 
 // Note: AudioPlayer component is now used as-is (no mock)

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -46,10 +46,12 @@ const Audio = () => {
   // Fetch timestamps when audio fileset changes
   useEffect(() => {
     if (!activeAudioFilesetId) return;
+    // Strip codec suffix (e.g. "ENGESHN1DA-opus16" -> "ENGESHN1DA")
+    const baseFilesetId = activeAudioFilesetId.split('-')[0];
     getAudioTimestamps(
       activeBook,
       activeChapter,
-      activeAudioFilesetId
+      baseFilesetId
     ).then(setTimestamps);
   }, [activeBook, activeChapter, activeAudioFilesetId]);
 

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from "react";
 import { Howl } from "howler";
 import { useBibleStore } from "../store";
-import { getKjvAudioUrl, getBibleAudioUrl, getPassage } from "../api";
+import { getKjvAudioUrl, getBibleAudioUrl, getAudioTimestamps, getPassage } from "../api";
 import { ActionIcon, rem, Loader } from "@mantine/core";
 import { IconPlayerPlay } from "@tabler/icons-react";
 import AudioPlayer from "./AudioPlayer";
+import { useVerseHighlighter } from "../hooks/useVerseHighlighter";
+import { VerseTimestamp } from "../types";
 
 const Audio = () => {
   const [isPlaying, setIsPlaying] = useState(false);
@@ -12,8 +14,12 @@ const Audio = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLooping, setIsLooping] = useState(false);
+  const [timestamps, setTimestamps] = useState<VerseTimestamp[]>([]);
   const activeBook = useBibleStore((state) => state.activeBook);
   const activeChapter = useBibleStore((state) => state.activeChapter);
+  const setAudioActiveVerse = useBibleStore(
+    (s) => s.setAudioActiveVerse
+  );
   const { activeAudioFilesetId, translations } = useBibleStore((state) => ({
     activeAudioFilesetId: state.activeAudioFilesetId,
     translations: state.translations,
@@ -33,7 +39,22 @@ const Audio = () => {
       audio.unload();
       setAudio(null);
     }
+    setTimestamps([]);
+    setAudioActiveVerse(null);
   }, [activeBook, activeChapter, activeAudioFilesetId]);
+
+  // Fetch timestamps when audio fileset changes
+  useEffect(() => {
+    if (!activeAudioFilesetId) return;
+    getAudioTimestamps(
+      activeBook,
+      activeChapter,
+      activeAudioFilesetId
+    ).then(setTimestamps);
+  }, [activeBook, activeChapter, activeAudioFilesetId]);
+
+  // Hook: highlight active verse during playback
+  useVerseHighlighter(audio, isPlaying, timestamps);
 
   // Setup Media Session API for hardware controls (headphones, lock screen, etc.)
   useEffect(() => {

--- a/src/components/Verse.tsx
+++ b/src/components/Verse.tsx
@@ -15,6 +15,13 @@ const useStyles = createStyles((theme) => ({
         : theme.colors.gray[2],
     color: theme.colorScheme === "dark" ? theme.white : theme.black,
   },
+  linkAudioActive: {
+    borderLeft: `3px solid ${theme.colors.blue[5]}`,
+    backgroundColor:
+      theme.colorScheme === 'dark'
+        ? theme.fn.rgba(theme.colors.blue[9], 0.15)
+        : theme.fn.rgba(theme.colors.blue[1], 0.5),
+  },
 }));
 
 const Verse = ({ verse, text }: { verse: number; text: string }) => {
@@ -22,7 +29,11 @@ const Verse = ({ verse, text }: { verse: number; text: string }) => {
   const { classes, cx } = useStyles();
   const activeVerses = useBibleStore((state) => state.activeVerses);
   const setActiveVerses = useBibleStore((state) => state.setActiveVerses);
+  const audioActiveVerse = useBibleStore(
+    (state) => state.audioActiveVerse
+  );
   const isActive = activeVerses.includes(verse);
+  const isAudioActive = audioActiveVerse === verse;
   
   // Track touch state to differentiate tap from scroll
   const [touchStartPos, setTouchStartPos] = useState<{
@@ -79,6 +90,15 @@ const Verse = ({ verse, text }: { verse: number; text: string }) => {
     userClickedRef.current = false;
   }, [isActive]);
 
+  useEffect(() => {
+    if (isAudioActive) {
+      ref.current?.scrollIntoView({
+        block: 'center',
+        behavior: 'smooth',
+      });
+    }
+  }, [isAudioActive]);
+
   return (
     <Box
       component="div"
@@ -86,6 +106,7 @@ const Verse = ({ verse, text }: { verse: number; text: string }) => {
       data-active={isActive}
       className={cx(classes.link, {
         [classes.linkActive]: isActive,
+        [classes.linkAudioActive]: isAudioActive,
       })}
       py={7}
       px={10}
@@ -100,7 +121,7 @@ const Verse = ({ verse, text }: { verse: number; text: string }) => {
       onTouchEnd={handleTouchEnd}
       onContextMenu={(e) => e.preventDefault()} // Prevent context menu
       id={"verse-" + verse}
-      ref={isActive ? ref : null}
+      ref={ref}
       sx={{
         touchAction: "pan-y", // Allow vertical scrolling
       }}

--- a/src/hooks/useVerseHighlighter.ts
+++ b/src/hooks/useVerseHighlighter.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { Howl } from 'howler';
+import { useBibleStore } from '../store';
+import { VerseTimestamp } from '../types';
+
+/**
+ * Polls audio playback position and sets the
+ * audio-active verse based on timestamps.
+ *
+ * Designed to work for both chapter-play and
+ * future note-play modes.
+ */
+export const useVerseHighlighter = (
+  audio: Howl | null,
+  isPlaying: boolean,
+  timestamps: VerseTimestamp[]
+) => {
+  const setAudioActiveVerse = useBibleStore(
+    (s) => s.setAudioActiveVerse
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    if (!audio || !isPlaying || timestamps.length === 0) {
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      const currentTime = audio.seek() as number;
+      if (typeof currentTime !== 'number') return;
+
+      // Binary search for the active verse
+      let lo = 0;
+      let hi = timestamps.length - 1;
+      let activeVerse = timestamps[0].verse_start;
+
+      while (lo <= hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        if (timestamps[mid].timestamp <= currentTime) {
+          activeVerse = timestamps[mid].verse_start;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+
+      setAudioActiveVerse(activeVerse);
+    }, 100);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [audio, isPlaying, timestamps, setAudioActiveVerse]);
+
+  // Clear on unmount
+  useEffect(() => {
+    return () => setAudioActiveVerse(null);
+  }, [setAudioActiveVerse]);
+};

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -36,6 +36,8 @@ interface BibleState {
   allNotesFetched: boolean;
   showNotes: boolean;
   lastSelectedTagId: string | null;
+  audioActiveVerse: number | null;
+  setAudioActiveVerse: (verse: number | null) => void;
   setActiveBook: (activeBook: string) => void;
   setActiveBookOnly: (activeBook: string) => void;
   setActiveBookShort: (activeBookShort: string) => void;
@@ -71,6 +73,7 @@ export const initialState = {
   allNotesFetched: false,
   showNotes: false,
   lastSelectedTagId: null,
+  audioActiveVerse: null as number | null,
 };
 
 export const useBibleStore = createWithEqualityFn<BibleState>()(
@@ -80,13 +83,15 @@ export const useBibleStore = createWithEqualityFn<BibleState>()(
       setActiveBook: (activeBook) => set({ 
         activeBook, 
         activeChapter: 1, 
-        activeVerses: [] 
+        activeVerses: [],
+        audioActiveVerse: null
       }),
       setActiveBookOnly: (activeBook) => set({ activeBook }),
       setActiveBookShort: (activeBookShort) => set({ activeBookShort }),
       setActiveChapter: (activeChapter) => set({ 
         activeChapter, 
-        activeVerses: [] 
+        activeVerses: [],
+        audioActiveVerse: null
       }),
       setActiveVerses: (activeVerses) => {
         set({ activeVerses });
@@ -184,6 +189,8 @@ export const useBibleStore = createWithEqualityFn<BibleState>()(
       },
       setShowNotes: (showNotes) => set({ showNotes }),
       setLastSelectedTagId: (lastSelectedTagId) => set({ lastSelectedTagId }),
+      setAudioActiveVerse: (audioActiveVerse) =>
+        set({ audioActiveVerse }),
     }),
     {
       name: "bible-storage",
@@ -199,6 +206,7 @@ export const useBibleStore = createWithEqualityFn<BibleState>()(
         activeTextFilesetId: state.activeTextFilesetId,
         activeAudioFilesetId: state.activeAudioFilesetId,
         lastSelectedTagId: state.lastSelectedTagId,
+        audioActiveVerse: state.audioActiveVerse,
         notes: state.notes,
         tags: state.tags,
         // showAudioPlayer is NOT persisted

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,8 @@ export interface Note {
   tag: Tag;
   verses: Verse[];
 }
+
+export interface VerseTimestamp {
+  verse_start: number;
+  timestamp: number;
+}

--- a/src/utils/cacheManager.ts
+++ b/src/utils/cacheManager.ts
@@ -1,4 +1,4 @@
-import { Note } from '../types';
+import { Note, VerseTimestamp } from '../types';
 import { Translation } from '../store';
 
 // Cache Manager for Bible Verses and Audio URLs
@@ -462,4 +462,53 @@ export const getCacheStats = () => {
       ).length,
     },
   };
+};
+
+// ============================================
+// TIMESTAMP CACHE (No expiration — immutable)
+// ============================================
+
+const TIMESTAMP_CACHE_KEY = 'bible_timestamp_cache';
+
+interface TimestampCache {
+  [key: string]: VerseTimestamp[];
+}
+
+export const getCachedTimestamps = (
+  filesetId: string,
+  book: string,
+  chapter: number
+): VerseTimestamp[] | null => {
+  try {
+    const cacheStr = getCachedLocalStorage(TIMESTAMP_CACHE_KEY);
+    if (!cacheStr) return null;
+
+    const cache: TimestampCache = JSON.parse(cacheStr);
+    const cacheKey = `${filesetId}:${book}:${chapter}`;
+    return cache[cacheKey] || null;
+  } catch (error) {
+    console.error('Error reading timestamp cache:', error);
+    return null;
+  }
+};
+
+export const cacheTimestamps = (
+  filesetId: string,
+  book: string,
+  chapter: number,
+  timestamps: VerseTimestamp[]
+) => {
+  try {
+    const cacheStr = getCachedLocalStorage(TIMESTAMP_CACHE_KEY);
+    const cache: TimestampCache = cacheStr ? JSON.parse(cacheStr) : {};
+    const cacheKey = `${filesetId}:${book}:${chapter}`;
+    cache[cacheKey] = timestamps;
+    setCachedLocalStorage(TIMESTAMP_CACHE_KEY, JSON.stringify(cache));
+  } catch (error) {
+    console.error('Error writing timestamp cache:', error);
+  }
+};
+
+export const clearTimestampCache = () => {
+  removeCachedLocalStorage(TIMESTAMP_CACHE_KEY);
 };


### PR DESCRIPTION
Adds frontend audio verse highlighting feature that highlights the currently spoken verse during audio playback.

### Changes
- **VerseTimestamp type**: New interface for timestamp data
- **Timestamp cache**: Added to cacheManager with no expiration (immutable data)
- **getAudioTimestamps()**: API function with caching and graceful degradation
- **audioActiveVerse**: New Zustand store state, reset on chapter/book change
- **useVerseHighlighter hook**: Binary search for active verse, polls at 100ms
- **Verse.tsx**: Blue left-border highlight style + auto-scroll for audio-active verse
- **Audio.tsx**: Fetches timestamps and wires useVerseHighlighter hook

### Requires
Backend PR: Bible-Research/bible-research#1 (timestamp endpoint)