### PR TITLE
feat: Display translation copyright at end of chapter

### DIFF
--- a/src/__tests__/api.copyright.test.ts
+++ b/src/__tests__/api.copyright.test.ts
@@ -10,9 +10,7 @@ import * as api from '../api';
 import * as cacheManager from '../utils/cacheManager';
 import { http, HttpResponse } from 'msw';
 import { server } from '../mocks/server';
-
-const API_BASE =
-  'http://localhost:8000';
+import { API_BASE_URL } from '../config';
 
 describe('getCopyrightInfo', () => {
   beforeEach(() => {
@@ -69,7 +67,7 @@ describe('getCopyrightInfo', () => {
   it('returns empty array on fetch failure', async () => {
     server.use(
       http.get(
-        `${API_BASE}/api/v1/bible/copyright/`,
+        `${API_BASE_URL}/api/v1/bible/copyright/`,
         () => new HttpResponse(null, { status: 500 })
       )
     );

--- a/src/__tests__/api.copyright.test.ts
+++ b/src/__tests__/api.copyright.test.ts
@@ -1,0 +1,83 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import * as api from '../api';
+import * as cacheManager from '../utils/cacheManager';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+
+const API_BASE =
+  'http://localhost:8000';
+
+describe('getCopyrightInfo', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(
+      cacheManager, 'getCachedCopyright'
+    ).mockReturnValue(null);
+    vi.spyOn(cacheManager, 'cacheCopyright');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns cached data without fetch', async () => {
+    const cached = [
+      {
+        id: 'ENGESV',
+        type: 'text_plain',
+        size: 'C',
+        copyright: '© 2001 Crossway',
+        copyright_date: '2001',
+        copyright_description: 'ESV Bible',
+      },
+    ];
+    (
+      cacheManager.getCachedCopyright as unknown as ReturnType<
+        typeof vi.spyOn
+      >
+    ).mockReturnValue(cached);
+
+    const result = await api.getCopyrightInfo(
+      'ENGESV'
+    );
+
+    expect(result).toEqual(cached);
+    expect(cacheManager.cacheCopyright).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches data on cache miss', async () => {
+    const result = await api.getCopyrightInfo(
+      'ENGESV'
+    );
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].id).toBe('ENGESV');
+    expect(result[0].type).toBe('text_plain');
+    expect(cacheManager.cacheCopyright).toHaveBeenCalledWith(
+      'ENGESV',
+      result
+    );
+  });
+
+  it('returns empty array on fetch failure', async () => {
+    server.use(
+      http.get(
+        `${API_BASE}/api/v1/bible/copyright/`,
+        () => new HttpResponse(null, { status: 500 })
+      )
+    );
+
+    const result = await api.getCopyrightInfo(
+      'ENGESV'
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -1,6 +1,6 @@
 import bibleJson from "./assets/kjv.json";
 import { Translation } from "./store";
-import { VerseTimestamp } from './types';
+import { VerseTimestamp, FilesetCopyright } from './types';
 
 import {
   getCachedVerses,
@@ -11,6 +11,8 @@ import {
   cacheTranslations,
   getCachedTimestamps,
   cacheTimestamps,
+  getCachedCopyright,
+  cacheCopyright,
 } from './utils/cacheManager';
 import { authenticatedFetch, publicFetch } from './utils/apiClient';
 import { API_BASE_URL } from './config';
@@ -559,6 +561,42 @@ export const prefetchAdjacentChapters = async (
 // ============================================
 // AUDIO TIMESTAMP FUNCTIONS
 // ============================================
+
+/**
+ * Fetch copyright info for a Bible translation.
+ * @param bibleId - The Bible abbreviation (e.g. "ENGESV")
+ * @returns Array of fileset copyright objects
+ */
+export const getCopyrightInfo = async (
+  bibleId: string
+): Promise<FilesetCopyright[]> => {
+  const cached = getCachedCopyright(bibleId);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const url =
+      `${API_BASE_URL}/api/v1/bible/copyright/` +
+      `?bible_id=${encodeURIComponent(bibleId)}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Copyright fetch failed: ${response.statusText}`
+      );
+    }
+    const data = await response.json();
+    const copyrights: FilesetCopyright[] =
+      data.data || [];
+    cacheCopyright(bibleId, copyrights);
+    return copyrights;
+  } catch (error) {
+    console.warn(
+      'Failed to fetch copyright info:', error
+    );
+    return [];
+  }
+};
 
 export const getAudioTimestamps = async (
   book: string,

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -579,7 +579,7 @@ export const getCopyrightInfo = async (
     const url =
       `${API_BASE_URL}/api/v1/bible/copyright/` +
       `?bible_id=${encodeURIComponent(bibleId)}`;
-    const response = await fetch(url);
+    const response = await publicFetch(url);
     if (!response.ok) {
       throw new Error(
         `Copyright fetch failed: ${response.statusText}`
@@ -614,7 +614,7 @@ export const getAudioTimestamps = async (
       `?fileset_id=${encodeURIComponent(filesetId)}` +
       `&book=${encodeURIComponent(book)}` +
       `&chapter=${chapter}`;
-    const response = await fetch(url);
+    const response = await publicFetch(url);
     if (!response.ok) {
       throw new Error(
         `Timestamps fetch failed: ${response.statusText}`

--- a/src/components/CopyrightNotice.tsx
+++ b/src/components/CopyrightNotice.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { Text, Box } from '@mantine/core';
+import { useBibleStore } from '../store';
+import { getCopyrightInfo } from '../api';
+import { shallow } from 'zustand/shallow';
+
+const CopyrightNotice = () => {
+  const { activeTextFilesetId, translations } =
+    useBibleStore(
+      (state) => ({
+        activeTextFilesetId: state.activeTextFilesetId,
+        translations: state.translations,
+      }),
+      shallow
+    );
+  const [copyright, setCopyright] = useState<string>('');
+
+  useEffect(() => {
+    if (!activeTextFilesetId || translations.length === 0) {
+      setCopyright('');
+      return;
+    }
+
+    // Find the bible_id (abbr) for the active text fileset
+    const translation = translations.find((t) =>
+      t.filesets.some(
+        (f) => f.id === activeTextFilesetId
+      )
+    );
+    if (!translation) {
+      setCopyright('');
+      return;
+    }
+
+    const bibleId = translation.abbr;
+
+    getCopyrightInfo(bibleId).then((data) => {
+      // Find the text fileset's copyright
+      const textCr = data.find(
+        (c) => c.id === activeTextFilesetId
+      );
+      // Fallback: use first text_plain type, then first entry
+      const cr =
+        textCr ||
+        data.find((c) => c.type === 'text_plain') ||
+        data[0];
+
+      if (cr) {
+        setCopyright(
+          cr.copyright_description || cr.copyright || ''
+        );
+      } else {
+        setCopyright('');
+      }
+    });
+  }, [activeTextFilesetId, translations]);
+
+  if (!copyright) return null;
+
+  return (
+    <Box py="md" px="sm">
+      <Text size="xs" color="dimmed" align="center" italic>
+        {copyright}
+      </Text>
+    </Box>
+  );
+};
+
+export default CopyrightNotice;

--- a/src/components/CopyrightNotice.tsx
+++ b/src/components/CopyrightNotice.tsx
@@ -33,8 +33,11 @@ const CopyrightNotice = () => {
     }
 
     const bibleId = translation.abbr;
+    let stale = false;
 
     getCopyrightInfo(bibleId).then((data) => {
+      if (stale) return;
+
       // Find the text fileset's copyright
       const textCr = data.find(
         (c) => c.id === activeTextFilesetId
@@ -46,15 +49,15 @@ const CopyrightNotice = () => {
         data[0];
 
       if (cr) {
-        setCopyright(
-          cr.copyright_description || cr.copyright || ''
-            ? `Copyright: ${cr.copyright_description || cr.copyright}`
-            : ''
-        );
+        const text =
+          cr.copyright_description || cr.copyright || '';
+        setCopyright(text ? `Copyright: ${text}` : '');
       } else {
         setCopyright('');
       }
     });
+
+    return () => { stale = true; };
   }, [activeTextFilesetId, translations]);
 
   if (!copyright) return null;

--- a/src/components/CopyrightNotice.tsx
+++ b/src/components/CopyrightNotice.tsx
@@ -48,6 +48,8 @@ const CopyrightNotice = () => {
       if (cr) {
         setCopyright(
           cr.copyright_description || cr.copyright || ''
+            ? `Copyright: ${cr.copyright_description || cr.copyright}`
+            : ''
         );
       } else {
         setCopyright('');

--- a/src/components/PassageView.tsx
+++ b/src/components/PassageView.tsx
@@ -7,6 +7,7 @@ import {
   prefetchAdjacentChapters,
 } from "../api";
 import Verse from "./Verse";
+import CopyrightNotice from "./CopyrightNotice";
 import { shallow } from 'zustand/shallow';
 
 const PassageView = () => {
@@ -71,6 +72,7 @@ const PassageView = () => {
         {verses.map((verse) => (
           <Verse verse={verse.verse} key={verse.verse} text={verse.text} />
         ))}
+        <CopyrightNotice />
       </Box>
     </ScrollArea>
   );

--- a/src/components/__tests__/CopyrightNotice.test.tsx
+++ b/src/components/__tests__/CopyrightNotice.test.tsx
@@ -98,6 +98,44 @@ describe('CopyrightNotice', () => {
     });
   });
 
+  it('renders nothing when activeTextFilesetId is null', async () => {
+    mockedGetCopyrightInfo.mockResolvedValue(
+      mockCopyrightData
+    );
+
+    const { container } = renderWithProviders(
+      <CopyrightNotice />,
+      {
+        stores: {
+          bible: {
+            activeTextFilesetId: null,
+            translations: [
+              {
+                abbr: 'ENGESV',
+                name: 'ESV',
+                language: 'English',
+                language_iso: 'eng',
+                filesets: [
+                  {
+                    id: 'ENGESV',
+                    type: 'text_plain',
+                    size: 'C',
+                    codec: null,
+                    bitrate: null,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe('');
+    });
+  });
+
   it('renders nothing when API returns empty array', async () => {
     mockedGetCopyrightInfo.mockResolvedValue([]);
 

--- a/src/components/__tests__/CopyrightNotice.test.tsx
+++ b/src/components/__tests__/CopyrightNotice.test.tsx
@@ -72,7 +72,7 @@ describe('CopyrightNotice', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          'The Holy Bible, English Standard Version'
+          'Copyright: The Holy Bible, English Standard Version'
         )
       ).toBeInTheDocument();
     });

--- a/src/components/__tests__/CopyrightNotice.test.tsx
+++ b/src/components/__tests__/CopyrightNotice.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+} from 'vitest';
+import CopyrightNotice from '../CopyrightNotice';
+import { renderWithProviders } from '../../__tests__/helpers';
+import { FilesetCopyright } from '../../types';
+
+const mockCopyrightData: FilesetCopyright[] = [
+  {
+    id: 'ENGESV',
+    type: 'text_plain',
+    size: 'C',
+    copyright: '© 2001 Crossway Bibles',
+    copyright_date: '2001',
+    copyright_description:
+      'The Holy Bible, English Standard Version',
+  },
+];
+
+vi.mock('../../api', () => ({
+  getCopyrightInfo: vi.fn(),
+}));
+
+import { getCopyrightInfo } from '../../api';
+
+const mockedGetCopyrightInfo =
+  getCopyrightInfo as unknown as ReturnType<
+    typeof vi.fn
+  >;
+
+describe('CopyrightNotice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders copyright text when data is available', async () => {
+    mockedGetCopyrightInfo.mockResolvedValue(
+      mockCopyrightData
+    );
+
+    renderWithProviders(<CopyrightNotice />, {
+      stores: {
+        bible: {
+          activeTextFilesetId: 'ENGESV',
+          translations: [
+            {
+              abbr: 'ENGESV',
+              name: 'English Standard Version',
+              language: 'English',
+              language_iso: 'eng',
+              filesets: [
+                {
+                  id: 'ENGESV',
+                  type: 'text_plain',
+                  size: 'C',
+                  codec: null,
+                  bitrate: null,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The Holy Bible, English Standard Version'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing with empty translations', async () => {
+    mockedGetCopyrightInfo.mockResolvedValue([]);
+
+    const { container } = renderWithProviders(
+      <CopyrightNotice />,
+      {
+        stores: {
+          bible: {
+            activeTextFilesetId: 'ENGESV',
+            translations: [],
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe('');
+    });
+  });
+
+  it('renders nothing when API returns empty array', async () => {
+    mockedGetCopyrightInfo.mockResolvedValue([]);
+
+    const { container } = renderWithProviders(
+      <CopyrightNotice />,
+      {
+        stores: {
+          bible: {
+            activeTextFilesetId: 'ENGESV',
+            translations: [
+              {
+                abbr: 'ENGESV',
+                name: 'ESV',
+                language: 'English',
+                language_iso: 'eng',
+                filesets: [
+                  {
+                    id: 'ENGESV',
+                    type: 'text_plain',
+                    size: 'C',
+                    codec: null,
+                    bitrate: null,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe('');
+    });
+  });
+});

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -96,30 +96,6 @@ export const handlers = [
       });
     }
   ),
-
-  // --- Copyright (local dev server) ---
-  http.get(
-    'http://localhost:8000/api/v1/bible/copyright/',
-    ({ request }) => {
-      const url = new URL(request.url);
-      const bibleId = url.searchParams.get(
-        'bible_id'
-      );
-      return HttpResponse.json({
-        data: [
-          {
-            id: bibleId || 'ENGESV',
-            type: 'text_plain',
-            size: 'C',
-            copyright: `© 2001 Test Copyright`,
-            copyright_date: '2001',
-            copyright_description:
-              'The Holy Bible, Test Version',
-          },
-        ],
-      });
-    }
-  ),
 ];
 
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -72,6 +72,54 @@ export const handlers = [
   http.delete(`${API_URL}/notes/:id`, () => {
     return HttpResponse.text('Deleted');
   }),
+
+  // --- Copyright ---
+  http.get(
+    `${API_URL}/bible/copyright/`,
+    ({ request }) => {
+      const url = new URL(request.url);
+      const bibleId = url.searchParams.get(
+        'bible_id'
+      );
+      return HttpResponse.json({
+        data: [
+          {
+            id: bibleId || 'ENGESV',
+            type: 'text_plain',
+            size: 'C',
+            copyright: `© 2001 Test Copyright`,
+            copyright_date: '2001',
+            copyright_description:
+              'The Holy Bible, Test Version',
+          },
+        ],
+      });
+    }
+  ),
+
+  // --- Copyright (local dev server) ---
+  http.get(
+    'http://localhost:8000/api/v1/bible/copyright/',
+    ({ request }) => {
+      const url = new URL(request.url);
+      const bibleId = url.searchParams.get(
+        'bible_id'
+      );
+      return HttpResponse.json({
+        data: [
+          {
+            id: bibleId || 'ENGESV',
+            type: 'text_plain',
+            size: 'C',
+            copyright: `© 2001 Test Copyright`,
+            copyright_date: '2001',
+            copyright_description:
+              'The Holy Bible, Test Version',
+          },
+        ],
+      });
+    }
+  ),
 ];
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,12 @@ export interface VerseTimestamp {
   verse_start: number;
   timestamp: number;
 }
+
+export interface FilesetCopyright {
+  id: string;
+  type: string;
+  size: string;
+  copyright: string;
+  copyright_date: string;
+  copyright_description: string;
+}

--- a/src/utils/__tests__/cacheManager.copyright.test.ts
+++ b/src/utils/__tests__/cacheManager.copyright.test.ts
@@ -1,0 +1,91 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  vi,
+} from 'vitest';
+import {
+  cacheCopyright,
+  getCachedCopyright,
+  clearCopyrightCache,
+} from '../cacheManager';
+import { FilesetCopyright } from '../../types';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+const sampleCopyright: FilesetCopyright[] = [
+  {
+    id: 'ENGESV',
+    type: 'text_plain',
+    size: 'C',
+    copyright: '© 2001 Crossway Bibles',
+    copyright_date: '2001',
+    copyright_description:
+      'The Holy Bible, English Standard Version',
+  },
+];
+
+describe('Copyright Cache', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    // Invalidate in-memory storageCache in cacheManager
+    // by simulating tab visibility change
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(
+      new Event('visibilitychange')
+    );
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    document.dispatchEvent(
+      new Event('visibilitychange')
+    );
+  });
+
+  it('stores and retrieves copyright data', () => {
+    cacheCopyright('ENGESV', sampleCopyright);
+    const result = getCachedCopyright('ENGESV');
+
+    expect(result).toEqual(sampleCopyright);
+  });
+
+  it('returns null on cache miss', () => {
+    const result = getCachedCopyright('ENGESV');
+
+    expect(result).toBeNull();
+  });
+
+  it('clears all copyright cache entries', () => {
+    cacheCopyright('ENGESV', sampleCopyright);
+    cacheCopyright('ENGKJV', []);
+
+    clearCopyrightCache();
+
+    expect(getCachedCopyright('ENGESV')).toBeNull();
+    expect(getCachedCopyright('ENGKJV')).toBeNull();
+  });
+});

--- a/src/utils/__tests__/cacheManager.copyright.test.ts
+++ b/src/utils/__tests__/cacheManager.copyright.test.ts
@@ -3,6 +3,7 @@ import {
   it,
   expect,
   beforeEach,
+  afterEach,
   vi,
 } from 'vitest';
 import {
@@ -11,6 +12,19 @@ import {
   clearCopyrightCache,
 } from '../cacheManager';
 import { FilesetCopyright } from '../../types';
+
+// Mock Date.now for TTL tests
+const REAL_NOW = Date.now;
+let mockNow: number;
+
+beforeEach(() => {
+  mockNow = 1000000000000;
+  Date.now = () => mockNow;
+});
+
+afterEach(() => {
+  Date.now = REAL_NOW;
+});
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -70,6 +84,26 @@ describe('Copyright Cache', () => {
     cacheCopyright('ENGESV', sampleCopyright);
     const result = getCachedCopyright('ENGESV');
 
+    expect(result).toEqual(sampleCopyright);
+  });
+
+  it('returns null when cache entry is expired', () => {
+    cacheCopyright('ENGESV', sampleCopyright);
+
+    // Advance past TTL (24h + 1ms)
+    mockNow += 24 * 60 * 60 * 1000 + 1;
+
+    const result = getCachedCopyright('ENGESV');
+    expect(result).toBeNull();
+  });
+
+  it('returns data when within TTL', () => {
+    cacheCopyright('ENGESV', sampleCopyright);
+
+    // Advance just under TTL
+    mockNow += 24 * 60 * 60 * 1000 - 1;
+
+    const result = getCachedCopyright('ENGESV');
     expect(result).toEqual(sampleCopyright);
   });
 

--- a/src/utils/cacheManager.ts
+++ b/src/utils/cacheManager.ts
@@ -514,13 +514,19 @@ export const clearTimestampCache = () => {
 };
 
 // ============================================
-// COPYRIGHT CACHE (No expiration — immutable)
+// COPYRIGHT CACHE (24h TTL)
 // ============================================
 
 const COPYRIGHT_CACHE_KEY = 'bible_copyright_cache';
+const COPYRIGHT_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+interface CopyrightCacheEntry {
+  data: FilesetCopyright[];
+  cachedAt: number;
+}
 
 interface CopyrightCache {
-  [bibleId: string]: FilesetCopyright[];
+  [bibleId: string]: CopyrightCacheEntry;
 }
 
 export const getCachedCopyright = (
@@ -533,7 +539,19 @@ export const getCachedCopyright = (
     if (!cacheStr) return null;
 
     const cache: CopyrightCache = JSON.parse(cacheStr);
-    return cache[bibleId] || null;
+    const entry = cache[bibleId];
+    if (!entry) return null;
+
+    if (Date.now() - entry.cachedAt > COPYRIGHT_CACHE_TTL) {
+      delete cache[bibleId];
+      setCachedLocalStorage(
+        COPYRIGHT_CACHE_KEY,
+        JSON.stringify(cache)
+      );
+      return null;
+    }
+
+    return entry.data;
   } catch (error) {
     console.error(
       'Error reading copyright cache:', error
@@ -553,7 +571,10 @@ export const cacheCopyright = (
     const cache: CopyrightCache = cacheStr
       ? JSON.parse(cacheStr)
       : {};
-    cache[bibleId] = data;
+    cache[bibleId] = {
+      data,
+      cachedAt: Date.now(),
+    };
     setCachedLocalStorage(
       COPYRIGHT_CACHE_KEY,
       JSON.stringify(cache)

--- a/src/utils/cacheManager.ts
+++ b/src/utils/cacheManager.ts
@@ -1,4 +1,4 @@
-import { Note, VerseTimestamp } from '../types';
+import { Note, VerseTimestamp, FilesetCopyright } from '../types';
 import { Translation } from '../store';
 
 // Cache Manager for Bible Verses and Audio URLs
@@ -511,4 +511,60 @@ export const cacheTimestamps = (
 
 export const clearTimestampCache = () => {
   removeCachedLocalStorage(TIMESTAMP_CACHE_KEY);
+};
+
+// ============================================
+// COPYRIGHT CACHE (No expiration — immutable)
+// ============================================
+
+const COPYRIGHT_CACHE_KEY = 'bible_copyright_cache';
+
+interface CopyrightCache {
+  [bibleId: string]: FilesetCopyright[];
+}
+
+export const getCachedCopyright = (
+  bibleId: string
+): FilesetCopyright[] | null => {
+  try {
+    const cacheStr = getCachedLocalStorage(
+      COPYRIGHT_CACHE_KEY
+    );
+    if (!cacheStr) return null;
+
+    const cache: CopyrightCache = JSON.parse(cacheStr);
+    return cache[bibleId] || null;
+  } catch (error) {
+    console.error(
+      'Error reading copyright cache:', error
+    );
+    return null;
+  }
+};
+
+export const cacheCopyright = (
+  bibleId: string,
+  data: FilesetCopyright[]
+) => {
+  try {
+    const cacheStr = getCachedLocalStorage(
+      COPYRIGHT_CACHE_KEY
+    );
+    const cache: CopyrightCache = cacheStr
+      ? JSON.parse(cacheStr)
+      : {};
+    cache[bibleId] = data;
+    setCachedLocalStorage(
+      COPYRIGHT_CACHE_KEY,
+      JSON.stringify(cache)
+    );
+  } catch (error) {
+    console.error(
+      'Error writing copyright cache:', error
+    );
+  }
+};
+
+export const clearCopyrightCache = () => {
+  removeCachedLocalStorage(COPYRIGHT_CACHE_KEY);
 };


### PR DESCRIPTION
## Summary
Displays copyright information for the active Bible translation at the bottom of every chapter view.

### Changes
- **FilesetCopyright type** — New TypeScript interface in `types.ts`
- **Copyright cache** — `getCachedCopyright`, `cacheCopyright`, `clearCopyrightCache` in `cacheManager.ts` (no expiration — immutable data)
- **getCopyrightInfo()** — API function with cache-first strategy in `api.tsx`
- **CopyrightNotice component** — React component that reads active fileset from store, fetches copyright, and renders dimmed italic text
- **PassageView wiring** — `<CopyrightNotice />` added after verses list

### Tests (9 total)
- 3 cache tests (store, retrieve, clear)
- 3 API tests (cache hit, fetch + cache, fetch failure)
- 3 component tests (renders copyright, empty translations, empty API response)

### Data Flow
```
PassageView → CopyrightNotice → getCopyrightInfo(abbr)
  → cache hit? → return cached
  → fetch /api/v1/bible/copyright/?bible_id=ENGESV
    → Django CopyrightView → DBTClient.get_copyright()
    → Response: [{id, type, copyright, ...}]
  → CopyrightNotice finds text fileset match
  → Renders: <Text italic dimmed>© ...</Text>
```

### Graceful Degradation
- If copyright fetch fails, chapter renders normally with no copyright footer
- If no matching fileset found, nothing renders