### PR TITLE
feat(translations): refresh translation list from API on modal open

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -113,4 +113,60 @@ describe('API Functions', () => {
       expect(removeNote).toBe('Deleted');
     });
   });
+
+  describe('getAvailableTranslations', () => {
+    const cached = [
+      {
+        abbr: 'KJV',
+        name: 'King James Version',
+        language: 'English',
+        language_iso: 'eng',
+        filesets: [{ id: 'ENGKJV', type: 'text_plain', size: 'NT' }],
+      },
+    ];
+
+    const fresh = [
+      ...cached,
+      {
+        abbr: 'NIV',
+        name: 'New International Version',
+        language: 'English',
+        language_iso: 'eng',
+        filesets: [{ id: 'ENGNIV', type: 'text_plain', size: 'C' }],
+      },
+    ];
+
+    beforeEach(() => {
+      vi.spyOn(cacheManager, 'getCachedTranslations');
+      vi.spyOn(cacheManager, 'cacheTranslations');
+    });
+
+    it('returns cached translations without hitting API', async () => {
+      vi.spyOn(cacheManager, 'getCachedTranslations')
+        .mockReturnValue(cached as any);
+      const fetchSpy = vi.spyOn(global, 'fetch');
+
+      const result = await api.getAvailableTranslations('eng');
+
+      expect(result).toEqual(cached);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('bypasses cache when forceRefresh=true and updates cache', async () => {
+      vi.spyOn(cacheManager, 'getCachedTranslations')
+        .mockReturnValue(cached as any);
+      server.use(
+        http.get(
+          `${API_URL}/bible/translations/`,
+          () => HttpResponse.json({ results: fresh })
+        )
+      );
+
+      const result = await api.getAvailableTranslations('eng', true);
+
+      expect(result).toEqual(fresh);
+      expect(cacheManager.cacheTranslations)
+        .toHaveBeenCalledWith('eng', fresh);
+    });
+  });
 });

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -301,12 +301,15 @@ export const deleteTag = async (tagId: string): Promise<void> => {
 // ============================================
 
 export const getAvailableTranslations = async (
-  languageIso = "eng"
+  languageIso = "eng",
+  forceRefresh = false
 ): Promise<Translation[]> => {
-  const cached = getCachedTranslations(languageIso);
-  if (cached) {
-    console.log(`✅ Translations for ${languageIso} loaded from cache`);
-    return cached;
+  if (!forceRefresh) {
+    const cached = getCachedTranslations(languageIso);
+    if (cached) {
+      console.log(`✅ Translations for ${languageIso} loaded from cache`);
+      return cached;
+    }
   }
 
   try {

--- a/src/components/TranslationSelector.test.tsx
+++ b/src/components/TranslationSelector.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import TranslationSelector from './TranslationSelector';
@@ -69,5 +69,102 @@ describe('TranslationSelector Component', () => {
 
     // This test is skipped because Select component renders
     // options in a portal that's not accessible in tests
+  });
+
+  it('refreshes translations from the API when modal opens', async () => {
+    const mock = api.getAvailableTranslations as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    render(<TranslationSelector />);
+
+    // Initial mount triggers a cached fetch (forceRefresh=false).
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith('eng');
+    });
+    mock.mockClear();
+
+    const button = screen.getByRole('button',
+      { name: 'Translations' });
+    fireEvent.click(button);
+
+    // Opening the modal must trigger an async refresh that
+    // bypasses the cache so newly available translations from
+    // the API show up without a manual cache bust.
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith('eng', true);
+    });
+  });
+
+  it('refreshes again on each re-open of the modal', async () => {
+    const mock = api.getAvailableTranslations as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    render(<TranslationSelector />);
+    const button = screen.getByRole('button',
+      { name: 'Translations' });
+
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith('eng', true);
+    });
+
+    // Close the modal.
+    fireEvent.click(screen.getByRole('button',
+      { name: /cancel/i }));
+
+    mock.mockClear();
+
+    // Re-open: must fetch fresh translations again.
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith('eng', true);
+    });
+  });
+
+  it('updates the translations store with freshly fetched list', async () => {
+    const setTranslations = vi.fn();
+    useBibleStore.setState({
+      ...initialStoreState,
+      translations: [],
+      activeTextFilesetId: 'ENGESV',
+      activeAudioFilesetId: null,
+      setTranslations,
+      setActiveTextFilesetId: vi.fn(),
+      setActiveAudioFilesetId: vi.fn(),
+    });
+
+    const freshTranslations = [
+      {
+        abbr: 'NIV',
+        name: 'New International Version',
+        language: 'English',
+        language_iso: 'eng',
+        filesets: [
+          { id: 'ENGNIV', type: 'text_plain', size: 'C' },
+        ],
+      },
+    ];
+    const mock = api.getAvailableTranslations as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    mock.mockImplementation(
+      (_iso: string, forceRefresh?: boolean) =>
+        Promise.resolve(
+          forceRefresh ? freshTranslations : []
+        )
+    );
+
+    render(<TranslationSelector />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Translations' })
+    );
+
+    await waitFor(() => {
+      expect(setTranslations).toHaveBeenCalledWith(
+        freshTranslations
+      );
+    });
   });
 });

--- a/src/components/TranslationSelector.tsx
+++ b/src/components/TranslationSelector.tsx
@@ -49,18 +49,37 @@ const TranslationSelector = () => {
   };
 
   useEffect(() => {
-    const fetchTranslations = async () => {
-      // Clear previous selections when language changes
-      setTranslations([]);
-      setSelectedTextId(null);
-      setSelectedAudioId(null);
+    let cancelled = false;
 
-      const fetched = await getAvailableTranslations(languageIso);
-      setTranslations(fetched);
+    const fetchTranslations = async () => {
+      // Show cached list immediately for snappy UX (stale)…
+      const cached = await getAvailableTranslations(languageIso);
+      if (!cancelled) {
+        setTranslations(cached);
+      }
+
+      // …then revalidate against the API so newly published
+      // translations show up without requiring a cache bust.
+      if (!opened) return;
+      const fresh = await getAvailableTranslations(languageIso, true);
+      if (!cancelled) {
+        setTranslations(fresh);
+      }
     };
 
     fetchTranslations();
-    // We only want this to run when the language changes.
+
+    return () => {
+      cancelled = true;
+    };
+    // We refetch whenever the modal is (re)opened or the language changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [languageIso, opened]);
+
+  useEffect(() => {
+    // Clear transient selections whenever the language changes.
+    setSelectedTextId(null);
+    setSelectedAudioId(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [languageIso]);
 


### PR DESCRIPTION
When the user opens the translation selector, the list of available
translations is now revalidated against the API (stale-while-revalidate).
Cached translations are rendered immediately, then replaced with the
freshly fetched list so new translations published on the server show
up without requiring a manual cache bust.

- Add forceRefresh flag to getAvailableTranslations() to bypass cache
- Revalidate translations whenever the modal opens or language changes
- Add api-level tests for cache hit and forceRefresh paths
- Add component tests verifying refresh on open/re-open and store update