### PR TITLE
feat: threaded comment feature on notes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   ColorScheme,
 } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
+import { ModalsProvider } from "@mantine/modals";
 import { useDisclosure, useLocalStorage, useWindowEvent } from "@mantine/hooks";
 import BibleSelector from "./components/BibleSelector";
 import MyHeader from "./components/MyHeader";
@@ -70,6 +71,7 @@ export default function App() {
         withGlobalStyles
         withNormalizeCSS
       >
+        <ModalsProvider>
         <Notifications position="top-right" zIndex={2077} />
         <AppShell
           padding="md"
@@ -118,6 +120,7 @@ export default function App() {
         </AppShell>
         <Analytics />
         <SpeedInsights />
+        </ModalsProvider>
       </MantineProvider>
     </ColorSchemeProvider>
   );

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from 'msw';
 import { server } from './mocks/server';
 
 const API_URL = 'https://bible-research-489314.ey.r.appspot.com/api/v1';
+const COMMENT_BASE = `${API_URL}`;
 
 describe('API Functions', () => {
   beforeEach(() => {
@@ -111,6 +112,48 @@ describe('API Functions', () => {
     it.skip('should make a DELETE request with note id', async () => {
       const removeNote = await api.deleteNote('abc-123');
       expect(removeNote).toBe('Deleted');
+    });
+  });
+
+  describe('fetchCommentCounts', () => {
+    it('chunks requests when noteIds exceeds 200', async () => {
+      const noteIds = Array.from(
+        { length: 201 },
+        (_, i) => `n${i}`
+      );
+      const result = await api.fetchCommentCounts({ noteIds });
+      expect(Object.keys(result).length).toBe(201);
+      noteIds.forEach((id) => {
+        expect(result[id]).toBe(1);
+      });
+    });
+
+    it('uses tag_id only and ignores noteIds when tagId is set', async () => {
+      let capturedUrl: string | undefined;
+      let callCount = 0;
+      server.use(
+        http.get(
+          `${COMMENT_BASE}/comments/counts/`,
+          ({ request }) => {
+            capturedUrl = request.url;
+            callCount++;
+            return HttpResponse.json({ counts: { 'note-x': 5 } });
+          }
+        )
+      );
+      const noteIds = Array.from(
+        { length: 201 },
+        (_, i) => `n${i}`
+      );
+      const result = await api.fetchCommentCounts({
+        tagId: 'tag-1',
+        noteIds,
+      });
+      expect(result).toEqual({ 'note-x': 5 });
+      expect(callCount).toBe(1);
+      const url = new URL(capturedUrl!);
+      expect(url.searchParams.get('tag_id')).toBe('tag-1');
+      expect(url.searchParams.has('note_ids')).toBe(false);
     });
   });
 

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -1,6 +1,12 @@
 import bibleJson from "./assets/kjv.json";
 import { Translation } from "./store";
-import { VerseTimestamp, FilesetCopyright } from './types';
+import {
+  VerseTimestamp,
+  FilesetCopyright,
+  Comment,
+  CommentAuthor,
+  CommentCounts,
+} from './types';
 
 import {
   getCachedVerses,
@@ -699,23 +705,7 @@ export const getNote = async (noteId: string): Promise<Note> => {
 // COMMENT TYPES
 // ============================================
 
-export interface CommentAuthor {
-  id: number;
-  username: string;
-}
-
-export interface Comment {
-  id: string;
-  author: CommentAuthor;
-  note_id: string;
-  parent_comment: string | null;
-  content: string;
-  timestamp: string;
-  is_deleted: boolean;
-  replies: Comment[];
-}
-
-export type CommentCounts = Record<string, number>;
+export type { Comment, CommentAuthor, CommentCounts };
 
 // ============================================
 // COMMENT FUNCTIONS
@@ -841,6 +831,9 @@ export const fetchCommentCounts = async (params: {
   };
 
   try {
+    if (tagId) {
+      return await fetchBatch();
+    }
     if (!noteIds || noteIds.length === 0) {
       return await fetchBatch();
     }

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -694,3 +694,170 @@ export const getNote = async (noteId: string): Promise<Note> => {
     throw error;
   }
 };
+
+// ============================================
+// COMMENT TYPES
+// ============================================
+
+export interface CommentAuthor {
+  id: number;
+  username: string;
+}
+
+export interface Comment {
+  id: string;
+  author: CommentAuthor;
+  note_id: string;
+  parent_comment: string | null;
+  content: string;
+  timestamp: string;
+  is_deleted: boolean;
+  replies: Comment[];
+}
+
+export type CommentCounts = Record<string, number>;
+
+// ============================================
+// COMMENT FUNCTIONS
+// ============================================
+
+export const fetchComments = async (
+  noteId: string
+): Promise<Comment[]> => {
+  try {
+    const response = await publicFetch(
+      `${API_BASE_URL}/api/v1/notes/${noteId}/comments/`
+    );
+    if (!response.ok) {
+      throw new Error('Failed to fetch comments');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching comments:', error);
+    throw error;
+  }
+};
+
+export const createComment = async (
+  noteId: string,
+  content: string,
+  parentCommentId?: string | null
+): Promise<Comment> => {
+  const body: Record<string, string> = { content };
+  if (parentCommentId) {
+    body.parent_comment = parentCommentId;
+  }
+  try {
+    const response = await authenticatedFetch(
+      `${API_BASE_URL}/api/v1/notes/${noteId}/comments/`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }
+    );
+    if (!response.ok) {
+      throw new Error('Failed to create comment');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error creating comment:', error);
+    throw error;
+  }
+};
+
+export const updateComment = async (
+  noteId: string,
+  commentId: string,
+  content: string
+): Promise<Comment> => {
+  try {
+    const response = await authenticatedFetch(
+      `${API_BASE_URL}/api/v1/notes/${noteId}/comments/${commentId}/`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ content }),
+      }
+    );
+    if (!response.ok) {
+      throw new Error('Failed to update comment');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error updating comment:', error);
+    throw error;
+  }
+};
+
+export const deleteComment = async (
+  noteId: string,
+  commentId: string
+): Promise<void> => {
+  try {
+    const response = await authenticatedFetch(
+      `${API_BASE_URL}/api/v1/notes/${noteId}/comments/${commentId}/`,
+      { method: 'DELETE' }
+    );
+    if (!response.ok && response.status !== 204) {
+      throw new Error('Failed to delete comment');
+    }
+  } catch (error) {
+    console.error('Error deleting comment:', error);
+    throw error;
+  }
+};
+
+export const fetchCommentCounts = async (params: {
+  tagId?: string;
+  noteIds?: string[];
+  includeDeleted?: boolean;
+}): Promise<CommentCounts> => {
+  const { tagId, noteIds, includeDeleted } = params;
+
+  const buildUrl = (ids?: string): string => {
+    const searchParams = new URLSearchParams();
+    if (tagId) {
+      searchParams.set('tag_id', tagId);
+    } else if (ids) {
+      searchParams.set('note_ids', ids);
+    }
+    if (includeDeleted) {
+      searchParams.set('include_deleted', 'true');
+    }
+    return (
+      `${API_BASE_URL}/api/v1/comments/counts/?` +
+      searchParams.toString()
+    );
+  };
+
+  const fetchBatch = async (
+    ids?: string
+  ): Promise<CommentCounts> => {
+    const response = await publicFetch(buildUrl(ids));
+    if (!response.ok) {
+      throw new Error('Failed to fetch comment counts');
+    }
+    const data = await response.json();
+    return data.counts as CommentCounts;
+  };
+
+  try {
+    if (!noteIds || noteIds.length === 0) {
+      return await fetchBatch();
+    }
+    const CHUNK_SIZE = 200;
+    if (noteIds.length <= CHUNK_SIZE) {
+      return await fetchBatch(noteIds.join(','));
+    }
+    const chunks: string[][] = [];
+    for (let i = 0; i < noteIds.length; i += CHUNK_SIZE) {
+      chunks.push(noteIds.slice(i, i + CHUNK_SIZE));
+    }
+    const results = await Promise.all(
+      chunks.map((chunk) => fetchBatch(chunk.join(',')))
+    );
+    return Object.assign({}, ...results) as CommentCounts;
+  } catch (error) {
+    console.error('Error fetching comment counts:', error);
+    throw error;
+  }
+};

--- a/src/components/CommentActions.tsx
+++ b/src/components/CommentActions.tsx
@@ -1,0 +1,59 @@
+import { Group, Button } from '@mantine/core';
+
+interface CommentActionsProps {
+  isAuthor: boolean;
+  isAuthenticated: boolean;
+  isDeleted: boolean;
+  onReplyClick: () => void;
+  onEditClick: () => void;
+  onDeleteClick: () => void;
+}
+
+const CommentActions = ({
+  isAuthor,
+  isAuthenticated,
+  isDeleted,
+  onReplyClick,
+  onEditClick,
+  onDeleteClick,
+}: CommentActionsProps) => {
+  if (isDeleted) return null;
+
+  return (
+    <Group spacing={4} mt={4}>
+      {isAuthenticated && (
+        <Button
+          size="xs"
+          variant="subtle"
+          compact
+          onClick={onReplyClick}
+        >
+          Reply
+        </Button>
+      )}
+      {isAuthor && (
+        <Button
+          size="xs"
+          variant="subtle"
+          compact
+          onClick={onEditClick}
+        >
+          Edit
+        </Button>
+      )}
+      {isAuthor && (
+        <Button
+          size="xs"
+          variant="subtle"
+          compact
+          color="red"
+          onClick={onDeleteClick}
+        >
+          Delete
+        </Button>
+      )}
+    </Group>
+  );
+};
+
+export default CommentActions;

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Group, Textarea, Button } from '@mantine/core';
+
+interface CommentFormProps {
+  initialValue?: string;
+  submitLabel?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  onSubmit: (content: string) => Promise<void>;
+  onCancel?: () => void;
+  submitting?: boolean;
+}
+
+const CommentForm = ({
+  initialValue = '',
+  submitLabel = 'Post',
+  placeholder = 'Write a comment…',
+  autoFocus = false,
+  onSubmit,
+  onCancel,
+  submitting = false,
+}: CommentFormProps) => {
+  const [value, setValue] = useState(initialValue);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!value.trim()) {
+      setError('Comment cannot be empty.');
+      return;
+    }
+    setError(null);
+    await onSubmit(value.trim());
+    setValue('');
+  };
+
+  return (
+    <div>
+      <Textarea
+        value={value}
+        onChange={(e) => setValue(e.currentTarget.value)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        minRows={2}
+        aria-label={placeholder}
+        error={error}
+        disabled={submitting}
+        mb={6}
+      />
+      <Group spacing="xs">
+        <Button
+          size="xs"
+          onClick={handleSubmit}
+          disabled={submitting}
+          loading={submitting}
+        >
+          {submitLabel}
+        </Button>
+        {onCancel && (
+          <Button
+            size="xs"
+            variant="subtle"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+        )}
+      </Group>
+    </div>
+  );
+};
+
+export default CommentForm;

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -22,6 +22,9 @@ const CommentForm = ({
 }: CommentFormProps) => {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState<string | null>(null);
+  const [localSubmitting, setLocalSubmitting] = useState(false);
+
+  const isDisabled = submitting || localSubmitting;
 
   const handleSubmit = async () => {
     if (!value.trim()) {
@@ -29,8 +32,13 @@ const CommentForm = ({
       return;
     }
     setError(null);
-    await onSubmit(value.trim());
-    setValue('');
+    setLocalSubmitting(true);
+    try {
+      await onSubmit(value.trim());
+      setValue('');
+    } finally {
+      setLocalSubmitting(false);
+    }
   };
 
   return (
@@ -43,15 +51,15 @@ const CommentForm = ({
         minRows={2}
         aria-label={placeholder}
         error={error}
-        disabled={submitting}
+        disabled={isDisabled}
         mb={6}
       />
       <Group spacing="xs">
         <Button
           size="xs"
           onClick={handleSubmit}
-          disabled={submitting}
-          loading={submitting}
+          disabled={isDisabled}
+          loading={isDisabled}
         >
           {submitLabel}
         </Button>
@@ -60,7 +68,7 @@ const CommentForm = ({
             size="xs"
             variant="subtle"
             onClick={onCancel}
-            disabled={submitting}
+            disabled={isDisabled}
           >
             Cancel
           </Button>

--- a/src/components/CommentNode.tsx
+++ b/src/components/CommentNode.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Box, Text, Stack } from '@mantine/core';
-import { Comment } from '../api';
+import { openConfirmModal } from '@mantine/modals';
+import { Comment } from '../types';
 import CommentForm from './CommentForm';
 import CommentActions from './CommentActions';
 
@@ -66,9 +67,13 @@ const CommentNode = ({
   };
 
   const handleDeleteClick = () => {
-    if (window.confirm('Delete this comment?')) {
-      onDelete(comment.id);
-    }
+    openConfirmModal({
+      title: 'Delete comment',
+      children: 'Are you sure you want to delete this comment?',
+      labels: { confirm: 'Delete', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => onDelete(comment.id),
+    });
   };
 
   return (
@@ -133,9 +138,9 @@ const CommentNode = ({
         </Stack>
       )}
 
-      {comment.replies.length > 0 && (
+      {(comment.replies?.length ?? 0) > 0 && (
         <Stack spacing={8} mt={8}>
-          {comment.replies.map((reply) => (
+          {comment.replies!.map((reply) => (
             <CommentNode
               key={reply.id}
               comment={reply}

--- a/src/components/CommentNode.tsx
+++ b/src/components/CommentNode.tsx
@@ -36,9 +36,20 @@ const CommentNode = ({
     comment.author.username === currentUsername;
   const indent = Math.min(depth, MAX_DEPTH) * 16;
 
-  const formatTime = (ts: string) => {
+  const formatTime = (ts: string): string => {
     try {
-      return new Date(ts).toLocaleString();
+      const diff = Date.now() - new Date(ts).getTime();
+      const seconds = Math.floor(diff / 1000);
+      if (seconds < 60) return 'just now';
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) {
+        return `${minutes}m ago`;
+      }
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      if (days < 30) return `${days}d ago`;
+      return new Date(ts).toLocaleDateString();
     } catch {
       return ts;
     }

--- a/src/components/CommentNode.tsx
+++ b/src/components/CommentNode.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { Box, Text, Stack } from '@mantine/core';
+import { Comment } from '../api';
+import CommentForm from './CommentForm';
+import CommentActions from './CommentActions';
+
+interface CommentNodeProps {
+  comment: Comment;
+  depth: number;
+  currentUsername: string | null;
+  isAuthenticated: boolean;
+  onReply: (
+    parentId: string,
+    content: string
+  ) => Promise<void>;
+  onUpdate: (id: string, content: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+const MAX_DEPTH = 6;
+
+const CommentNode = ({
+  comment,
+  depth,
+  currentUsername,
+  isAuthenticated,
+  onReply,
+  onUpdate,
+  onDelete,
+}: CommentNodeProps) => {
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const isAuthor =
+    !!currentUsername &&
+    comment.author.username === currentUsername;
+  const indent = Math.min(depth, MAX_DEPTH) * 16;
+
+  const formatTime = (ts: string) => {
+    try {
+      return new Date(ts).toLocaleString();
+    } catch {
+      return ts;
+    }
+  };
+
+  const handleReplySubmit = async (content: string) => {
+    await onReply(comment.id, content);
+    setReplyOpen(false);
+  };
+
+  const handleEditSubmit = async (content: string) => {
+    await onUpdate(comment.id, content);
+    setEditing(false);
+  };
+
+  const handleDeleteClick = () => {
+    if (window.confirm('Delete this comment?')) {
+      onDelete(comment.id);
+    }
+  };
+
+  return (
+    <Box
+      pl={indent}
+      sx={(theme) => ({
+        borderLeft:
+          depth > 0
+            ? `2px solid ${
+                theme.colorScheme === 'dark'
+                  ? theme.colors.dark[4]
+                  : theme.colors.gray[3]
+              }`
+            : 'none',
+      })}
+    >
+      {comment.is_deleted ? (
+        <Text size="sm" color="dimmed" fs="italic" py={4}>
+          [deleted]
+        </Text>
+      ) : (
+        <Stack spacing={4}>
+          <Text size="xs" color="dimmed">
+            <strong>{comment.author.username}</strong>{' '}
+            &middot; {formatTime(comment.timestamp)}
+          </Text>
+
+          {editing ? (
+            <CommentForm
+              initialValue={comment.content}
+              submitLabel="Save"
+              autoFocus
+              onSubmit={handleEditSubmit}
+              onCancel={() => setEditing(false)}
+            />
+          ) : (
+            <Text size="sm">{comment.content}</Text>
+          )}
+
+          {!editing && (
+            <CommentActions
+              isAuthor={isAuthor}
+              isAuthenticated={isAuthenticated}
+              isDeleted={comment.is_deleted}
+              onReplyClick={() => setReplyOpen((o) => !o)}
+              onEditClick={() => setEditing(true)}
+              onDeleteClick={handleDeleteClick}
+            />
+          )}
+
+          {replyOpen && (
+            <Box mt={6}>
+              <CommentForm
+                submitLabel="Reply"
+                placeholder="Write a reply…"
+                autoFocus
+                onSubmit={handleReplySubmit}
+                onCancel={() => setReplyOpen(false)}
+              />
+            </Box>
+          )}
+        </Stack>
+      )}
+
+      {comment.replies.length > 0 && (
+        <Stack spacing={8} mt={8}>
+          {comment.replies.map((reply) => (
+            <CommentNode
+              key={reply.id}
+              comment={reply}
+              depth={depth + 1}
+              currentUsername={currentUsername}
+              isAuthenticated={isAuthenticated}
+              onReply={onReply}
+              onUpdate={onUpdate}
+              onDelete={onDelete}
+            />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+export default CommentNode;

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -74,12 +74,37 @@ const CommentThread = ({
       });
   }, [noteId]);
 
+  const silentLoad = useCallback(() => {
+    const version = ++loadVersion.current;
+    fetchComments(noteId)
+      .then((data) => {
+        if (loadVersion.current === version)
+          setComments(normalize(data));
+      })
+      .catch(() => {
+        // background refresh — don't surface errors
+      });
+  }, [noteId]);
+
   useEffect(() => {
     load();
     return () => {
       loadVersion.current++;
     };
   }, [load]);
+
+  useEffect(() => {
+    const POLL_MS = 30_000;
+    const poll = () => {
+      if (document.visibilityState === 'visible') silentLoad();
+    };
+    const id = setInterval(poll, POLL_MS);
+    document.addEventListener('visibilitychange', poll);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', poll);
+    };
+  }, [silentLoad]);
 
   const handleCreate = async (
     parentId: string | null,
@@ -100,6 +125,7 @@ const CommentThread = ({
         )
       );
       onCountChange?.(1);
+      silentLoad();
     } catch {
       showNotification({
         color: 'red',
@@ -117,6 +143,7 @@ const CommentThread = ({
       setComments((prev) =>
         updateNode(prev, id, () => normalize([updated])[0])
       );
+      silentLoad();
     } catch {
       showNotification({
         color: 'red',
@@ -137,6 +164,7 @@ const CommentThread = ({
         }))
       );
       onCountChange?.(-1);
+      silentLoad();
     } catch {
       showNotification({
         color: 'red',

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -44,23 +44,13 @@ const CommentThread = ({
   const currentUsername =
     useAuthStore((state) => state.user)?.username ?? null;
 
-  const load = async () => {
-    let cancelled = false;
+  const load = () => {
     setLoading(true);
     setError(null);
-    try {
-      const data = await fetchComments(noteId);
-      if (!cancelled) setComments(data);
-    } catch {
-      if (!cancelled) {
-        setError('Failed to load comments.');
-      }
-    } finally {
-      if (!cancelled) setLoading(false);
-    }
-    return () => {
-      cancelled = true;
-    };
+    fetchComments(noteId)
+      .then((data) => setComments(data))
+      .catch(() => setError('Failed to load comments.'))
+      .finally(() => setLoading(false));
   };
 
   useEffect(() => {
@@ -158,7 +148,12 @@ const CommentThread = ({
         <Text color="red" size="sm">
           {error}
         </Text>
-        <Button size="xs" variant="subtle" onClick={load}>
+        <Button
+          size="xs"
+          variant="subtle"
+          onClick={load}
+          aria-label="Retry loading comments"
+        >
           Retry
         </Button>
       </Stack>

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -44,11 +44,17 @@ const CommentThread = ({
   const currentUsername =
     useAuthStore((state) => state.user)?.username ?? null;
 
+  const normalize = (nodes: Comment[]): Comment[] =>
+    (nodes ?? []).map((c) => ({
+      ...c,
+      replies: normalize(c.replies),
+    }));
+
   const load = () => {
     setLoading(true);
     setError(null);
     fetchComments(noteId)
-      .then((data) => setComments(data))
+      .then((data) => setComments(normalize(data)))
       .catch(() => setError('Failed to load comments.'))
       .finally(() => setLoading(false));
   };
@@ -59,7 +65,7 @@ const CommentThread = ({
     setError(null);
     fetchComments(noteId)
       .then((data) => {
-        if (!cancel) setComments(data);
+        if (!cancel) setComments(normalize(data));
       })
       .catch(() => {
         if (!cancel) setError('Failed to load comments.');
@@ -84,7 +90,11 @@ const CommentThread = ({
         parentId
       );
       setComments((prev) =>
-        insertReply(prev, parentId, newComment)
+        insertReply(
+          prev,
+          parentId,
+          normalize([newComment])[0]
+        )
       );
       onCountChange?.(1);
     } catch {
@@ -102,7 +112,7 @@ const CommentThread = ({
     try {
       const updated = await updateComment(noteId, id, content);
       setComments((prev) =>
-        updateNode(prev, id, () => updated)
+        updateNode(prev, id, () => normalize([updated])[0])
       );
     } catch {
       showNotification({

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Stack,
   Text,
@@ -8,7 +8,8 @@ import {
   Button,
 } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { Comment } from '../api';
+import { Link } from 'react-router-dom';
+import { Comment } from '../types';
 import {
   fetchComments,
   createComment,
@@ -24,6 +25,14 @@ import { useAuthStore } from '../stores/authStore';
 import CommentForm from './CommentForm';
 import CommentNode from './CommentNode';
 
+const normalize = (
+  nodes: Comment[] | undefined
+): Comment[] =>
+  (nodes ?? []).map((c) => ({
+    ...c,
+    replies: normalize(c.replies),
+  }));
+
 interface CommentThreadProps {
   noteId: string;
   onCountChange?: (delta: number) => void;
@@ -38,45 +47,39 @@ const CommentThread = ({
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
+  const loadVersion = useRef(0);
+
   const isAuthenticated = useAuthStore(
     (state) => state.isAuthenticated
   );
   const currentUsername =
     useAuthStore((state) => state.user)?.username ?? null;
 
-  const normalize = (nodes: Comment[]): Comment[] =>
-    (nodes ?? []).map((c) => ({
-      ...c,
-      replies: normalize(c.replies),
-    }));
-
-  const load = () => {
-    setLoading(true);
-    setError(null);
-    fetchComments(noteId)
-      .then((data) => setComments(normalize(data)))
-      .catch(() => setError('Failed to load comments.'))
-      .finally(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    let cancel = false;
+  const load = useCallback(() => {
+    const version = ++loadVersion.current;
     setLoading(true);
     setError(null);
     fetchComments(noteId)
       .then((data) => {
-        if (!cancel) setComments(normalize(data));
+        if (loadVersion.current === version)
+          setComments(normalize(data));
       })
       .catch(() => {
-        if (!cancel) setError('Failed to load comments.');
+        if (loadVersion.current === version)
+          setError('Failed to load comments.');
       })
       .finally(() => {
-        if (!cancel) setLoading(false);
+        if (loadVersion.current === version)
+          setLoading(false);
       });
-    return () => {
-      cancel = true;
-    };
   }, [noteId]);
+
+  useEffect(() => {
+    load();
+    return () => {
+      loadVersion.current++;
+    };
+  }, [load]);
 
   const handleCreate = async (
     parentId: string | null,
@@ -133,6 +136,7 @@ const CommentThread = ({
           content: '[deleted]',
         }))
       );
+      onCountChange?.(-1);
     } catch {
       showNotification({
         color: 'red',
@@ -147,7 +151,7 @@ const CommentThread = ({
   if (loading) {
     return (
       <Center py={16}>
-        <Loader size="sm" />
+        <Loader size="sm" data-testid="thread-loader" />
       </Center>
     );
   }
@@ -182,7 +186,7 @@ const CommentThread = ({
         ) : (
           <Text size="sm" color="dimmed">
             No comments yet.{' '}
-            <a href="/login">Log in to comment</a>.
+            <Link to="/login">Log in to comment</Link>.
           </Text>
         )
       ) : (

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from 'react';
+import {
+  Stack,
+  Text,
+  Loader,
+  Center,
+  Divider,
+  Button,
+} from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { Comment } from '../api';
+import {
+  fetchComments,
+  createComment,
+  updateComment,
+  deleteComment,
+} from '../api';
+import {
+  insertReply,
+  updateNode,
+  pruneDeleted,
+} from '../utils/commentTree';
+import { useAuthStore } from '../stores/authStore';
+import CommentForm from './CommentForm';
+import CommentNode from './CommentNode';
+
+interface CommentThreadProps {
+  noteId: string;
+  onCountChange?: (delta: number) => void;
+}
+
+const CommentThread = ({
+  noteId,
+  onCountChange,
+}: CommentThreadProps) => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isAuthenticated = useAuthStore(
+    (state) => state.isAuthenticated
+  );
+  const currentUsername =
+    useAuthStore((state) => state.user)?.username ?? null;
+
+  const load = async () => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchComments(noteId);
+      if (!cancelled) setComments(data);
+    } catch {
+      if (!cancelled) {
+        setError('Failed to load comments.');
+      }
+    } finally {
+      if (!cancelled) setLoading(false);
+    }
+    return () => {
+      cancelled = true;
+    };
+  };
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    setError(null);
+    fetchComments(noteId)
+      .then((data) => {
+        if (!cancel) setComments(data);
+      })
+      .catch(() => {
+        if (!cancel) setError('Failed to load comments.');
+      })
+      .finally(() => {
+        if (!cancel) setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [noteId]);
+
+  const handleCreate = async (
+    parentId: string | null,
+    content: string
+  ) => {
+    setSubmitting(true);
+    try {
+      const newComment = await createComment(
+        noteId,
+        content,
+        parentId
+      );
+      setComments((prev) =>
+        insertReply(prev, parentId, newComment)
+      );
+      onCountChange?.(1);
+    } catch {
+      showNotification({
+        color: 'red',
+        title: 'Error',
+        message: 'Failed to post comment.',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUpdate = async (id: string, content: string) => {
+    try {
+      const updated = await updateComment(noteId, id, content);
+      setComments((prev) =>
+        updateNode(prev, id, () => updated)
+      );
+    } catch {
+      showNotification({
+        color: 'red',
+        title: 'Error',
+        message: 'Failed to update comment.',
+      });
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteComment(noteId, id);
+      setComments((prev) =>
+        updateNode(prev, id, (n) => ({
+          ...n,
+          is_deleted: true,
+          content: '[deleted]',
+        }))
+      );
+    } catch {
+      showNotification({
+        color: 'red',
+        title: 'Error',
+        message: 'Failed to delete comment.',
+      });
+    }
+  };
+
+  const visible = pruneDeleted(comments);
+
+  if (loading) {
+    return (
+      <Center py={16}>
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Stack spacing={4} py={8}>
+        <Text color="red" size="sm">
+          {error}
+        </Text>
+        <Button size="xs" variant="subtle" onClick={load}>
+          Retry
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={12} pt={8}>
+      <Divider />
+
+      {visible.length === 0 ? (
+        isAuthenticated ? (
+          <Text size="sm" color="dimmed">
+            No comments yet.
+          </Text>
+        ) : (
+          <Text size="sm" color="dimmed">
+            No comments yet.{' '}
+            <a href="/login">Log in to comment</a>.
+          </Text>
+        )
+      ) : (
+        <Stack spacing={12}>
+          {visible.map((c) => (
+            <CommentNode
+              key={c.id}
+              comment={c}
+              depth={0}
+              currentUsername={currentUsername}
+              isAuthenticated={isAuthenticated}
+              onReply={(parentId, content) =>
+                handleCreate(parentId, content)
+              }
+              onUpdate={handleUpdate}
+              onDelete={handleDelete}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {isAuthenticated && (
+        <CommentForm
+          placeholder="Add a comment…"
+          submitLabel="Post"
+          submitting={submitting}
+          onSubmit={(content) => handleCreate(null, content)}
+        />
+      )}
+    </Stack>
+  );
+};
+
+export default CommentThread;

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -76,6 +76,8 @@ const NoteCard = ({
     }
   };
 
+  // commentCount is undefined on the detail route, which renders
+  // its own always-expanded CommentThread – no badge needed there.
   const showCommentButton = commentCount === undefined
     ? false
     : commentCount > 0 || isAuthenticated;
@@ -139,6 +141,11 @@ const NoteCard = ({
                 compact
                 leftIcon={
                   <IconMessageCircle size={14} />
+                }
+                aria-label={
+                  commentCount === 0
+                    ? 'Add a comment'
+                    : undefined
                 }
                 aria-expanded={threadOpen}
                 aria-controls={`comment-thread-${note.id}`}

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -1,18 +1,36 @@
 import type { MouseEvent } from "react";
-import { Card, Title, Text, Group, Box } from "@mantine/core";
+import { useState } from "react";
+import { Card, Title, Text, Group, Box, Button, Tooltip } from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
+import { IconMessageCircle } from "@tabler/icons-react";
 import { Note } from "../types";
+import { useAuthStore } from "../stores/authStore";
 import Verse from "./Verse";
-import Button from "./Button";
+import ButtonComponent from "./Button";
+import CommentThread from "./CommentThread";
 
 interface NoteCardProps {
   note: Note;
   onViewInBible: (book: string, chapter: number, verse: number) => void;
   onEdit?: (note: Note) => void;
   onDelete?: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
+  commentCount?: number;
+  onCountChange?: (delta: number) => void;
 }
 
-const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {  
+const NoteCard = ({
+  note,
+  onViewInBible,
+  onEdit,
+  onDelete,
+  commentCount,
+  onCountChange,
+}: NoteCardProps) => {
+  const [threadOpen, setThreadOpen] = useState(false);
+  const isAuthenticated = useAuthStore(
+    (state) => state.isAuthenticated
+  );
+
   const firstVerse = note?.verses?.[0]?.verse || 1;
   const lastVerse = note?.verses?.[note.verses.length - 1]?.verse || 1;
   const book = note?.verses?.[0]?.book || "";
@@ -58,38 +76,42 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
     }
   };
 
+  const showCommentButton = commentCount === undefined
+    ? false
+    : commentCount > 0 || isAuthenticated;
+
   return (
     <Card shadow="sm" padding="sm" radius="md" mb={15}>
       <Group position="apart" mb={0}>
         <Title order={4}>{heading}</Title>
         <Group spacing="xs">
-          <Button
+          <ButtonComponent
             variant="subtle"
             size="xs"
             onClick={() => onViewInBible(book, chapter, firstVerse)}
           >
             View in Bible
-          </Button>
+          </ButtonComponent>
           {canShare && (
-            <Button
+            <ButtonComponent
               variant="subtle"
               size="xs"
               onClick={handleShare}
             >
               Share
-            </Button>
+            </ButtonComponent>
           )}
           {canEdit && (
-            <Button
+            <ButtonComponent
               variant="subtle"
               size="xs"
               onClick={() => onEdit!(note)}
             >
               Edit
-            </Button>
+            </ButtonComponent>
           )}
           {canDelete && (
-            <Button
+            <ButtonComponent
               variant="subtle"
               size="xs"
               onClick={
@@ -98,7 +120,37 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
               }
             >
               Remove
-            </Button>
+            </ButtonComponent>
+          )}
+          {showCommentButton && (
+            <Tooltip
+              label={
+                commentCount === 0
+                  ? 'Add a comment'
+                  : `${commentCount} comment${
+                      commentCount === 1 ? '' : 's'
+                    }`
+              }
+              position="top"
+            >
+              <Button
+                variant="subtle"
+                size="xs"
+                compact
+                leftIcon={
+                  <IconMessageCircle size={14} />
+                }
+                aria-expanded={threadOpen}
+                aria-controls={`comment-thread-${note.id}`}
+                onClick={() =>
+                  setThreadOpen((o) => !o)
+                }
+              >
+                {commentCount && commentCount > 0
+                  ? String(commentCount)
+                  : null}
+              </Button>
+            </Tooltip>
           )}
         </Group>
       </Group>
@@ -124,6 +176,18 @@ const NoteCard = ({ note, onViewInBible, onEdit, onDelete }: NoteCardProps) => {
           {note.note_text}
         </Text>
       </Box>
+
+      {threadOpen && (
+        <Box
+          id={`comment-thread-${note.id}`}
+          mt={8}
+        >
+          <CommentThread
+            noteId={note.id}
+            onCountChange={onCountChange}
+          />
+        </Box>
+      )}
     </Card>
   );
 };

--- a/src/components/TagSection.tsx
+++ b/src/components/TagSection.tsx
@@ -1,29 +1,52 @@
 import type { MouseEvent } from "react";
 import { Title, Stack } from "@mantine/core";
-import { Note } from "../types";
+import { Note, CommentCounts } from "../types";
 import NoteCard from "./NoteCard";
 
 interface TagSectionProps {
   tagName: string;
   notes: Note[];
-  onViewInBible: (book: string, chapter: number, verse: number) => void;
+  onViewInBible: (
+    book: string,
+    chapter: number,
+    verse: number
+  ) => void;
   onEditNote?: (note: Note) => void;
-  onDeleteNote?: (evt: MouseEvent<HTMLButtonElement>, note: Note) => void;
+  onDeleteNote?: (
+    evt: MouseEvent<HTMLButtonElement>,
+    note: Note
+  ) => void;
+  commentCounts?: CommentCounts;
+  onCountChange?: (noteId: string, delta: number) => void;
 }
 
-const TagSection = ({ tagName, notes, onViewInBible, onEditNote, onDeleteNote }: TagSectionProps) => {
+const TagSection = ({
+  tagName,
+  notes,
+  onViewInBible,
+  onEditNote,
+  onDeleteNote,
+  commentCounts,
+  onCountChange,
+}: TagSectionProps) => {
   return (
     <Stack spacing="md" mb={30}>
       <Title order={2} mb={5}>
         {tagName}
       </Title>
       {notes.map((note) => (
-        <NoteCard 
-          key={note.id} 
-          note={note} 
-          onViewInBible={onViewInBible} 
-          onEdit={onEditNote} 
-          onDelete={onDeleteNote} 
+        <NoteCard
+          key={note.id}
+          note={note}
+          onViewInBible={onViewInBible}
+          onEdit={onEditNote}
+          onDelete={onDeleteNote}
+          commentCount={commentCounts?.[note.id]}
+          onCountChange={
+            onCountChange
+              ? (delta) => onCountChange(note.id, delta)
+              : undefined
+          }
         />
       ))}
     </Stack>

--- a/src/components/__tests__/CommentForm.test.tsx
+++ b/src/components/__tests__/CommentForm.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CommentForm from '../CommentForm';
+import { renderWithProviders } from '../../__tests__/helpers';
+
+describe('CommentForm', () => {
+  it('renders textarea and submit button', () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    expect(
+      screen.getByRole('textbox')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Post' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders custom submitLabel', () => {
+    renderWithProviders(
+      <CommentForm
+        submitLabel="Reply"
+        onSubmit={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Reply' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows cancel button when onCancel provided', () => {
+    renderWithProviders(
+      <CommentForm
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Cancel' })
+    ).toBeInTheDocument();
+  });
+
+  it('does not show cancel button when onCancel absent', () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows error when submitting empty content', async () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Post' })
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Comment cannot be empty.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls onSubmit with trimmed content', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <CommentForm onSubmit={onSubmit} />
+    );
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '  hello world  ' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Post' })
+    );
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  it('calls onCancel when cancel is clicked', () => {
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <CommentForm
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel' })
+    );
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('prefills textarea with initialValue', () => {
+    renderWithProviders(
+      <CommentForm
+        initialValue="existing text"
+        onSubmit={vi.fn()}
+      />
+    );
+    expect(
+      (screen.getByRole('textbox') as HTMLTextAreaElement)
+        .value
+    ).toBe('existing text');
+  });
+});

--- a/src/components/__tests__/CommentNode.test.tsx
+++ b/src/components/__tests__/CommentNode.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CommentNode from '../CommentNode';
+import { renderWithProviders } from '../../__tests__/helpers';
+import { Comment } from '../../api';
+
+const makeComment = (overrides: Partial<Comment> = {}): Comment => ({
+  id: 'c1',
+  author: { id: 1, username: 'alice' },
+  note_id: 'note-1',
+  parent_comment: null,
+  content: 'Hello world',
+  timestamp: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  replies: [],
+  ...overrides,
+});
+
+const defaultProps = {
+  depth: 0,
+  currentUsername: 'alice',
+  isAuthenticated: true,
+  onReply: vi.fn().mockResolvedValue(undefined),
+  onUpdate: vi.fn().mockResolvedValue(undefined),
+  onDelete: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('CommentNode', () => {
+  it('renders comment content and author', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+      />
+    );
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+  });
+
+  it('renders tombstone for deleted comment', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ is_deleted: true })}
+        {...defaultProps}
+      />
+    );
+    expect(screen.getByText('[deleted]')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Hello world')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Reply button when authenticated', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+        isAuthenticated={true}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Reply' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides Reply button when unauthenticated', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+        isAuthenticated={false}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Reply' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Edit and Delete for the author', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+        currentUsername="alice"
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Edit' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides Edit and Delete for non-author', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+        currentUsername="bob"
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Edit' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows reply form when Reply is clicked', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment()}
+        {...defaultProps}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reply' })
+    );
+    expect(
+      screen.getByRole('button', { name: 'Cancel' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Write a reply…')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nested replies recursively', () => {
+    const reply: Comment = makeComment({
+      id: 'c2',
+      content: 'A nested reply',
+      parent_comment: 'c1',
+    });
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ replies: [reply] })}
+        {...defaultProps}
+      />
+    );
+    expect(
+      screen.getByText('A nested reply')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/CommentThread.test.tsx
+++ b/src/components/__tests__/CommentThread.test.tsx
@@ -15,8 +15,9 @@ import { http, HttpResponse } from 'msw';
 import CommentThread from '../CommentThread';
 import { renderWithProviders } from '../../__tests__/helpers';
 import { server } from '../../mocks/server';
+import { API_BASE_URL } from '../../config';
 
-const API_URL = 'http://localhost:8000/api/v1';
+const API_URL = `${API_BASE_URL}/api/v1`;
 
 const NOTE_ID = 'note-1';
 

--- a/src/components/__tests__/CommentThread.test.tsx
+++ b/src/components/__tests__/CommentThread.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import {
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+} from 'vitest';
+import { http, HttpResponse } from 'msw';
+import CommentThread from '../CommentThread';
+import { renderWithProviders } from '../../__tests__/helpers';
+import { server } from '../../mocks/server';
+
+const API_URL = 'http://localhost:8000/api/v1';
+
+const NOTE_ID = 'note-1';
+
+describe('CommentThread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loader initially', () => {
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />
+    );
+    expect(
+      document.querySelector('.mantine-Loader-root') ||
+        document.querySelector('[data-testid="loader"]') ||
+        document.querySelector('svg')
+    ).toBeTruthy();
+  });
+
+  it('renders comments after fetch', async () => {
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Test comment')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows "No comments yet" when list is empty', async () => {
+    server.use(
+      http.get(
+        `${API_URL}/notes/note-1/comments/`,
+        () => HttpResponse.json([])
+      )
+    );
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No comments yet/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on fetch failure', async () => {
+    server.use(
+      http.get(
+        `${API_URL}/notes/note-1/comments/`,
+        () => HttpResponse.error()
+      )
+    );
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to load comments/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows comment form for authenticated users', async () => {
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Test comment')
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByPlaceholderText('Add a comment…')
+    ).toBeInTheDocument();
+  });
+
+  it('hides comment form for unauthenticated users', async () => {
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: false,
+            user: null,
+            token: null,
+          },
+        },
+      }
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Test comment')
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByPlaceholderText('Add a comment…')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onCountChange with +1 after successful create', async () => {
+    const onCountChange = vi.fn();
+    renderWithProviders(
+      <CommentThread
+        noteId={NOTE_ID}
+        onCountChange={onCountChange}
+      />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Add a comment…')
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Add a comment…'),
+      { target: { value: 'My new comment' } }
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => {
+      expect(onCountChange).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/components/__tests__/CommentThread.test.tsx
+++ b/src/components/__tests__/CommentThread.test.tsx
@@ -11,6 +11,13 @@ import {
   vi,
   beforeEach,
 } from 'vitest';
+
+vi.mock('@mantine/modals', () => ({
+  openConfirmModal: vi.fn(
+    ({ onConfirm }: { onConfirm?: () => void }) =>
+      onConfirm?.()
+  ),
+}));
 import { http, HttpResponse } from 'msw';
 import CommentThread from '../CommentThread';
 import { renderWithProviders } from '../../__tests__/helpers';
@@ -31,10 +38,8 @@ describe('CommentThread', () => {
       <CommentThread noteId={NOTE_ID} />
     );
     expect(
-      document.querySelector('.mantine-Loader-root') ||
-        document.querySelector('[data-testid="loader"]') ||
-        document.querySelector('svg')
-    ).toBeTruthy();
+      screen.getByTestId('thread-loader')
+    ).toBeInTheDocument();
   });
 
   it('renders comments after fetch', async () => {
@@ -126,6 +131,77 @@ describe('CommentThread', () => {
     expect(
       screen.queryByPlaceholderText('Add a comment…')
     ).not.toBeInTheDocument();
+  });
+
+  it('calls onCountChange with -1 after successful delete', async () => {
+    const onCountChange = vi.fn();
+    renderWithProviders(
+      <CommentThread
+        noteId={NOTE_ID}
+        onCountChange={onCountChange}
+      />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Test comment')
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete' })
+    );
+
+    await waitFor(() => {
+      expect(onCountChange).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  it('updates comment content after successful edit', async () => {
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Test comment')
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edit' })
+    );
+    fireEvent.change(
+      screen.getByDisplayValue('Test comment'),
+      { target: { value: 'Updated content' } }
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save' })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Updated content')
+      ).toBeInTheDocument();
+    });
   });
 
   it('calls onCountChange with +1 after successful create', async () => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,9 @@
 import { http, HttpResponse } from 'msw';
+import { API_BASE_URL } from '../config';
 
 // Define your request handlers
 const API_URL = 'https://bible-research-489314.ey.r.appspot.com/api/v1';
-const LOCAL_API_URL = 'http://localhost:8000/api/v1';
+const COMMENT_BASE = `${API_BASE_URL}/api/v1`;
 
 export const handlers = [
   // --- Single /bible Endpoint Handler ---
@@ -74,8 +75,8 @@ export const handlers = [
     return HttpResponse.text('Deleted');
   }),
 
-  // --- Comments (intercepted on both prod and local URLs) ---
-  http.get(`${LOCAL_API_URL}/notes/:noteId/comments/`, ({ params }) => {
+  // --- Comments ---
+  http.get(`${COMMENT_BASE}/notes/:noteId/comments/`, ({ params }) => {
     return HttpResponse.json([
       {
         id: 'comment-1',
@@ -91,7 +92,7 @@ export const handlers = [
   }),
 
   http.post(
-    `${LOCAL_API_URL}/notes/:noteId/comments/`,
+    `${COMMENT_BASE}/notes/:noteId/comments/`,
     async ({ params, request }) => {
       const body = await request.json() as any;
       return HttpResponse.json({
@@ -108,7 +109,7 @@ export const handlers = [
   ),
 
   http.patch(
-    `${LOCAL_API_URL}/notes/:noteId/comments/:commentId/`,
+    `${COMMENT_BASE}/notes/:noteId/comments/:commentId/`,
     async ({ params, request }) => {
       const body = await request.json() as any;
       return HttpResponse.json({
@@ -125,14 +126,14 @@ export const handlers = [
   ),
 
   http.delete(
-    `${LOCAL_API_URL}/notes/:noteId/comments/:commentId/`,
+    `${COMMENT_BASE}/notes/:noteId/comments/:commentId/`,
     () => {
       return new HttpResponse(null, { status: 204 });
     }
   ),
 
   // --- Comment Counts ---
-  http.get(`${LOCAL_API_URL}/comments/counts/`, ({ request }) => {
+  http.get(`${COMMENT_BASE}/comments/counts/`, ({ request }) => {
     const url = new URL(request.url);
     const noteIds = url.searchParams.get('note_ids');
     const counts: Record<string, number> = {};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 
 // Define your request handlers
 const API_URL = 'https://bible-research-489314.ey.r.appspot.com/api/v1';
+const LOCAL_API_URL = 'http://localhost:8000/api/v1';
 
 export const handlers = [
   // --- Single /bible Endpoint Handler ---
@@ -71,6 +72,76 @@ export const handlers = [
   // --- Delete Note ---
   http.delete(`${API_URL}/notes/:id`, () => {
     return HttpResponse.text('Deleted');
+  }),
+
+  // --- Comments (intercepted on both prod and local URLs) ---
+  http.get(`${LOCAL_API_URL}/notes/:noteId/comments/`, ({ params }) => {
+    return HttpResponse.json([
+      {
+        id: 'comment-1',
+        author: { id: 1, username: 'testuser' },
+        note_id: params.noteId,
+        parent_comment: null,
+        content: 'Test comment',
+        timestamp: new Date().toISOString(),
+        is_deleted: false,
+        replies: [],
+      },
+    ]);
+  }),
+
+  http.post(
+    `${LOCAL_API_URL}/notes/:noteId/comments/`,
+    async ({ params, request }) => {
+      const body = await request.json() as any;
+      return HttpResponse.json({
+        id: 'comment-new',
+        author: { id: 1, username: 'testuser' },
+        note_id: params.noteId,
+        parent_comment: body.parent_comment || null,
+        content: body.content,
+        timestamp: new Date().toISOString(),
+        is_deleted: false,
+        replies: [],
+      }, { status: 201 });
+    }
+  ),
+
+  http.patch(
+    `${LOCAL_API_URL}/notes/:noteId/comments/:commentId/`,
+    async ({ params, request }) => {
+      const body = await request.json() as any;
+      return HttpResponse.json({
+        id: params.commentId,
+        author: { id: 1, username: 'testuser' },
+        note_id: params.noteId,
+        parent_comment: null,
+        content: body.content,
+        timestamp: new Date().toISOString(),
+        is_deleted: false,
+        replies: [],
+      });
+    }
+  ),
+
+  http.delete(
+    `${LOCAL_API_URL}/notes/:noteId/comments/:commentId/`,
+    () => {
+      return new HttpResponse(null, { status: 204 });
+    }
+  ),
+
+  // --- Comment Counts ---
+  http.get(`${LOCAL_API_URL}/comments/counts/`, ({ request }) => {
+    const url = new URL(request.url);
+    const noteIds = url.searchParams.get('note_ids');
+    const counts: Record<string, number> = {};
+    if (noteIds) {
+      noteIds.split(',').forEach((id) => {
+        counts[id] = 1;
+      });
+    }
+    return HttpResponse.json({ counts });
   }),
 
   // --- Copyright ---

--- a/src/routes/NoteDetailRoute.tsx
+++ b/src/routes/NoteDetailRoute.tsx
@@ -14,6 +14,7 @@ import { IconShare } from '@tabler/icons-react';
 import { showNotification } from '@mantine/notifications';
 import { Note } from '../types';
 import NoteCard from '../components/NoteCard';
+import CommentThread from '../components/CommentThread';
 import { getNote } from '../api';
 import { useBibleStore } from '../store';
 
@@ -148,6 +149,7 @@ export default function NoteDetailRoute() {
           note={note}
           onViewInBible={handleViewInBible}
         />
+        <CommentThread noteId={note.id} />
       </Stack>
     </Box>
   );

--- a/src/routes/TagNotesRoute.tsx
+++ b/src/routes/TagNotesRoute.tsx
@@ -15,11 +15,11 @@ import {
 import { IconShare, IconRefresh } from '@tabler/icons-react';
 import { showNotification } from '@mantine/notifications';
 import type { MouseEvent } from 'react';
-import { Note, Tag } from '../types';
+import { Note, Tag, CommentCounts } from '../types';
 import TagSection from '../components/TagSection';
 import EditNoteModal from '../components/EditNoteModal';
 import { useBibleStore } from '../store';
-import { deleteNote, getTag } from '../api';
+import { deleteNote, getTag, fetchCommentCounts } from '../api';
 import { useAuthStore } from '../stores/authStore';
 import { clearNotesCache } from '../utils/cacheManager';
 
@@ -46,6 +46,8 @@ export default function TagNotesRoute() {
   const [tag, setTag] = useState<Tag | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [commentCounts, setCommentCounts] =
+    useState<CommentCounts>({});
 
   // Set showNotes to true and save lastSelectedTagId when on notes route
   useEffect(() => {
@@ -100,6 +102,12 @@ export default function TagNotesRoute() {
           setTag(resolvedTag);
         }
         setLoading(false);
+
+        if (!cancelled && tagId) {
+          fetchCommentCounts({ tagId }).then((counts) => {
+            if (!cancelled) setCommentCounts(counts);
+          }).catch(() => {});
+        }
       } catch (err) {
         if (cancelled) return;
         console.error('Error loading tag notes:', err);
@@ -150,6 +158,16 @@ export default function TagNotesRoute() {
     
     // Switch to Bible view
     setShowNotes(false);
+  };
+
+  const handleCountChange = (
+    noteId: string,
+    delta: number
+  ) => {
+    setCommentCounts((prev) => ({
+      ...prev,
+      [noteId]: (prev[noteId] ?? 0) + delta,
+    }));
   };
 
   const handleTagChange = (value: string | null) => {
@@ -299,8 +317,16 @@ export default function TagNotesRoute() {
               tagName={tag.name}
               notes={notes}
               onViewInBible={handleViewInBible}
-              onEditNote={isAuthenticated ? handleEditNote : undefined}
-              onDeleteNote={isAuthenticated ? handleDeleteNote : undefined}
+              onEditNote={
+                isAuthenticated ? handleEditNote : undefined
+              }
+              onDeleteNote={
+                isAuthenticated
+                  ? handleDeleteNote
+                  : undefined
+              }
+              commentCounts={commentCounts}
+              onCountChange={handleCountChange}
             />
           </Stack>
         ) : (

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,3 +37,9 @@ export interface FilesetCopyright {
   copyright_date: string;
   copyright_description: string;
 }
+
+export type {
+  Comment,
+  CommentAuthor,
+  CommentCounts,
+} from './api';

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,20 @@ export interface FilesetCopyright {
   copyright_description: string;
 }
 
-export type {
-  Comment,
-  CommentAuthor,
-  CommentCounts,
-} from './api';
+export interface CommentAuthor {
+  id: number;
+  username: string;
+}
+
+export interface Comment {
+  id: string;
+  author: CommentAuthor;
+  note_id: string;
+  parent_comment: string | null;
+  content: string;
+  timestamp: string;
+  is_deleted: boolean;
+  replies: Comment[] | undefined;
+}
+
+export type CommentCounts = Record<string, number>;

--- a/src/utils/__tests__/commentTree.test.ts
+++ b/src/utils/__tests__/commentTree.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  insertReply,
+  updateNode,
+  pruneDeleted,
+} from '../commentTree';
+import { Comment } from '../../api';
+
+const makeComment = (
+  id: string,
+  opts: Partial<Comment> = {}
+): Comment => ({
+  id,
+  author: { id: 1, username: 'user' },
+  note_id: 'note-1',
+  parent_comment: null,
+  content: `comment ${id}`,
+  timestamp: '2024-01-01T00:00:00Z',
+  is_deleted: false,
+  replies: [],
+  ...opts,
+});
+
+describe('insertReply', () => {
+  it('appends to root when parentId is null', () => {
+    const tree = [makeComment('1')];
+    const newC = makeComment('2');
+    const result = insertReply(tree, null, newC);
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe('2');
+  });
+
+  it('inserts as reply to matching parent', () => {
+    const tree = [makeComment('1')];
+    const newC = makeComment('2', { parent_comment: '1' });
+    const result = insertReply(tree, '1', newC);
+    expect(result[0].replies).toHaveLength(1);
+    expect(result[0].replies[0].id).toBe('2');
+  });
+
+  it('inserts deep into nested tree', () => {
+    const child = makeComment('2', { parent_comment: '1' });
+    const tree = [makeComment('1', { replies: [child] })];
+    const grandchild = makeComment('3', { parent_comment: '2' });
+    const result = insertReply(tree, '2', grandchild);
+    expect(result[0].replies[0].replies).toHaveLength(1);
+    expect(result[0].replies[0].replies[0].id).toBe('3');
+  });
+
+  it('does not mutate the original tree', () => {
+    const tree = [makeComment('1')];
+    insertReply(tree, null, makeComment('2'));
+    expect(tree).toHaveLength(1);
+  });
+});
+
+describe('updateNode', () => {
+  it('applies updater to matching node', () => {
+    const tree = [makeComment('1', { content: 'old' })];
+    const result = updateNode(tree, '1', (n) => ({
+      ...n,
+      content: 'new',
+    }));
+    expect(result[0].content).toBe('new');
+  });
+
+  it('applies updater to deep nested node', () => {
+    const child = makeComment('2', { content: 'old' });
+    const tree = [makeComment('1', { replies: [child] })];
+    const result = updateNode(tree, '2', (n) => ({
+      ...n,
+      content: 'updated',
+    }));
+    expect(result[0].replies[0].content).toBe('updated');
+  });
+
+  it('does not mutate the original tree', () => {
+    const tree = [makeComment('1', { content: 'orig' })];
+    updateNode(tree, '1', (n) => ({ ...n, content: 'new' }));
+    expect(tree[0].content).toBe('orig');
+  });
+});
+
+describe('pruneDeleted', () => {
+  it('keeps non-deleted nodes', () => {
+    const tree = [makeComment('1'), makeComment('2')];
+    expect(pruneDeleted(tree)).toHaveLength(2);
+  });
+
+  it('removes deleted leaf nodes', () => {
+    const tree = [
+      makeComment('1'),
+      makeComment('2', { is_deleted: true }),
+    ];
+    const result = pruneDeleted(tree);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('keeps deleted node as tombstone if it has surviving replies', () => {
+    const reply = makeComment('2', { parent_comment: '1' });
+    const tree = [
+      makeComment('1', { is_deleted: true, replies: [reply] }),
+    ];
+    const result = pruneDeleted(tree);
+    expect(result).toHaveLength(1);
+    expect(result[0].is_deleted).toBe(true);
+    expect(result[0].replies).toHaveLength(1);
+  });
+
+  it('removes deleted node when all replies are also deleted', () => {
+    const reply = makeComment('2', {
+      is_deleted: true,
+      parent_comment: '1',
+    });
+    const tree = [
+      makeComment('1', { is_deleted: true, replies: [reply] }),
+    ];
+    const result = pruneDeleted(tree);
+    expect(result).toHaveLength(0);
+  });
+
+  it('prunes deleted replies but keeps parent', () => {
+    const deleted = makeComment('2', {
+      is_deleted: true,
+      parent_comment: '1',
+    });
+    const tree = [makeComment('1', { replies: [deleted] })];
+    const result = pruneDeleted(tree);
+    expect(result[0].replies).toHaveLength(0);
+  });
+});

--- a/src/utils/commentTree.ts
+++ b/src/utils/commentTree.ts
@@ -1,4 +1,4 @@
-import { Comment } from '../api';
+import { Comment } from '../types';
 
 /**
  * Insert a new comment as a reply to the given parentId.
@@ -55,16 +55,6 @@ export function updateNode(
 }
 
 /**
- * Returns true if the subtree rooted at `node` contains at least
- * one non-deleted descendant (not counting the node itself).
- */
-function hasSurvivingDescendant(node: Comment): boolean {
-  return replies(node).some(
-    (r) => !r.is_deleted || hasSurvivingDescendant(r)
-  );
-}
-
-/**
  * Prune deleted comments from the tree:
  * - Deleted leaf nodes are removed entirely.
  * - Deleted nodes that have surviving descendants are kept as
@@ -78,11 +68,7 @@ export function pruneDeleted(tree: Comment[]): Comment[] {
       acc.push(nodeWithPruned);
       return acc;
     }
-    const surviving =
-      prunedReplies.some((r) => !r.is_deleted) ||
-      (prunedReplies.length > 0 &&
-        prunedReplies.some((r) => hasSurvivingDescendant(r)));
-    if (surviving || prunedReplies.length > 0) {
+    if (prunedReplies.length > 0) {
       acc.push(nodeWithPruned);
     }
     return acc;

--- a/src/utils/commentTree.ts
+++ b/src/utils/commentTree.ts
@@ -1,0 +1,83 @@
+import { Comment } from '../api';
+
+/**
+ * Insert a new comment as a reply to the given parentId.
+ * If parentId is null, appends to the root list.
+ */
+export function insertReply(
+  tree: Comment[],
+  parentId: string | null,
+  newComment: Comment
+): Comment[] {
+  if (parentId === null) {
+    return [...tree, newComment];
+  }
+  return tree.map((node) => {
+    if (node.id === parentId) {
+      return { ...node, replies: [...node.replies, newComment] };
+    }
+    if (node.replies.length > 0) {
+      return {
+        ...node,
+        replies: insertReply(node.replies, parentId, newComment),
+      };
+    }
+    return node;
+  });
+}
+
+/**
+ * Apply updater to the node with the given id (deep).
+ */
+export function updateNode(
+  tree: Comment[],
+  id: string,
+  updater: (node: Comment) => Comment
+): Comment[] {
+  return tree.map((node) => {
+    if (node.id === id) {
+      return updater(node);
+    }
+    if (node.replies.length > 0) {
+      return {
+        ...node,
+        replies: updateNode(node.replies, id, updater),
+      };
+    }
+    return node;
+  });
+}
+
+/**
+ * Returns true if the subtree rooted at `node` contains at least
+ * one non-deleted descendant (not counting the node itself).
+ */
+function hasSurvivingDescendant(node: Comment): boolean {
+  return node.replies.some(
+    (r) => !r.is_deleted || hasSurvivingDescendant(r)
+  );
+}
+
+/**
+ * Prune deleted comments from the tree:
+ * - Deleted leaf nodes are removed entirely.
+ * - Deleted nodes that have surviving descendants are kept as
+ *   tombstones (is_deleted stays true, replies preserved).
+ */
+export function pruneDeleted(tree: Comment[]): Comment[] {
+  return tree.reduce<Comment[]>((acc, node) => {
+    const prunedReplies = pruneDeleted(node.replies);
+    const nodeWithPruned = { ...node, replies: prunedReplies };
+    if (!node.is_deleted) {
+      acc.push(nodeWithPruned);
+      return acc;
+    }
+    const surviving = prunedReplies.some((r) => !r.is_deleted) ||
+      prunedReplies.length > 0 &&
+      prunedReplies.some((r) => hasSurvivingDescendant(r));
+    if (surviving || prunedReplies.length > 0) {
+      acc.push(nodeWithPruned);
+    }
+    return acc;
+  }, []);
+}

--- a/src/utils/commentTree.ts
+++ b/src/utils/commentTree.ts
@@ -4,22 +4,28 @@ import { Comment } from '../api';
  * Insert a new comment as a reply to the given parentId.
  * If parentId is null, appends to the root list.
  */
+const replies = (node: Comment): Comment[] =>
+  node.replies ?? [];
+
 export function insertReply(
   tree: Comment[],
   parentId: string | null,
   newComment: Comment
 ): Comment[] {
   if (parentId === null) {
-    return [...tree, newComment];
+    return [...(tree ?? []), newComment];
   }
-  return tree.map((node) => {
+  return (tree ?? []).map((node) => {
     if (node.id === parentId) {
-      return { ...node, replies: [...node.replies, newComment] };
-    }
-    if (node.replies.length > 0) {
       return {
         ...node,
-        replies: insertReply(node.replies, parentId, newComment),
+        replies: [...replies(node), newComment],
+      };
+    }
+    if (replies(node).length > 0) {
+      return {
+        ...node,
+        replies: insertReply(replies(node), parentId, newComment),
       };
     }
     return node;
@@ -34,14 +40,14 @@ export function updateNode(
   id: string,
   updater: (node: Comment) => Comment
 ): Comment[] {
-  return tree.map((node) => {
+  return (tree ?? []).map((node) => {
     if (node.id === id) {
       return updater(node);
     }
-    if (node.replies.length > 0) {
+    if (replies(node).length > 0) {
       return {
         ...node,
-        replies: updateNode(node.replies, id, updater),
+        replies: updateNode(replies(node), id, updater),
       };
     }
     return node;
@@ -53,7 +59,7 @@ export function updateNode(
  * one non-deleted descendant (not counting the node itself).
  */
 function hasSurvivingDescendant(node: Comment): boolean {
-  return node.replies.some(
+  return replies(node).some(
     (r) => !r.is_deleted || hasSurvivingDescendant(r)
   );
 }
@@ -65,16 +71,17 @@ function hasSurvivingDescendant(node: Comment): boolean {
  *   tombstones (is_deleted stays true, replies preserved).
  */
 export function pruneDeleted(tree: Comment[]): Comment[] {
-  return tree.reduce<Comment[]>((acc, node) => {
-    const prunedReplies = pruneDeleted(node.replies);
+  return (tree ?? []).reduce<Comment[]>((acc, node) => {
+    const prunedReplies = pruneDeleted(replies(node));
     const nodeWithPruned = { ...node, replies: prunedReplies };
     if (!node.is_deleted) {
       acc.push(nodeWithPruned);
       return acc;
     }
-    const surviving = prunedReplies.some((r) => !r.is_deleted) ||
-      prunedReplies.length > 0 &&
-      prunedReplies.some((r) => hasSurvivingDescendant(r));
+    const surviving =
+      prunedReplies.some((r) => !r.is_deleted) ||
+      (prunedReplies.length > 0 &&
+        prunedReplies.some((r) => hasSurvivingDescendant(r)));
     if (surviving || prunedReplies.length > 0) {
       acc.push(nodeWithPruned);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",


### PR DESCRIPTION
## Summary

Implements a full threaded comment system on Bible notes per COMMENT_FEATURE_PLAN.md.

## Changes

### API layer
- Added `CommentAuthor`, `Comment`, `CommentCounts` types to `api.tsx` / `types.ts`
- Added `fetchComments`, `createComment`, `updateComment`, `deleteComment`, `fetchCommentCounts`

### Utilities
- `src/utils/commentTree.ts` — `insertReply`, `updateNode`, `pruneDeleted` for immutable comment tree manipulation

### Components
- **CommentForm** — textarea + submit/cancel buttons
- **CommentActions** — reply / edit / delete action row
- **CommentNode** — recursive renderer with inline reply/edit forms, relative timestamps, depth-capped indentation
- **CommentThread** — fetches thread, manages optimistic state, loader/error/empty states

### Integration
- **NoteDetailRoute** — always-expanded `CommentThread` below the note
- **NoteCard** — collapsible inline thread via `IconMessageCircle` badge toggle
- **TagNotesRoute** — bulk-fetches counts via `fetchCommentCounts({ tagId })`, threaded through `TagSection` → `NoteCard`

### Tests
- 35 passing tests (12 unit + 23 component/integration)
- MSW handlers keyed to `http://localhost:8000` to match test `.env`
