### PR TITLE
feat: comment image attachments

### DIFF
--- a/src/__tests__/helpers.tsx
+++ b/src/__tests__/helpers.tsx
@@ -97,6 +97,11 @@ export function mockDomApis() {
     unobserve: vi.fn(),
     disconnect: vi.fn(),
   }));
+
+  // Mock URL.createObjectURL / revokeObjectURL — happy-dom
+  // doesn't support File as a Blob subclass
+  global.URL.createObjectURL = vi.fn(() => 'blob:test-url');
+  global.URL.revokeObjectURL = vi.fn();
 }
 
 /**

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -6,6 +6,7 @@ import {
   Comment,
   CommentAuthor,
   CommentCounts,
+  CommentImage,
 } from './types';
 
 import {
@@ -20,7 +21,7 @@ import {
   getCachedCopyright,
   cacheCopyright,
 } from './utils/cacheManager';
-import { authenticatedFetch, publicFetch } from './utils/apiClient';
+import { authenticatedFetch, authenticatedUpload, publicFetch } from './utils/apiClient';
 import { API_BASE_URL } from './config';
 
 export const data = bibleJson as KjvBook[];
@@ -705,7 +706,7 @@ export const getNote = async (noteId: string): Promise<Note> => {
 // COMMENT TYPES
 // ============================================
 
-export type { Comment, CommentAuthor, CommentCounts };
+export type { Comment, CommentAuthor, CommentCounts, CommentImage };
 
 // ============================================
 // COMMENT FUNCTIONS
@@ -794,6 +795,53 @@ export const deleteComment = async (
     console.error('Error deleting comment:', error);
     throw error;
   }
+};
+
+export const uploadCommentImage = async (
+  noteId: string,
+  commentId: string,
+  file: File,
+): Promise<CommentImage> => {
+  const fd = new FormData();
+  fd.append('file', file);
+  const response = await authenticatedUpload(
+    `${API_BASE_URL}/api/v1/notes/${noteId}/comments/${commentId}/images/`,
+    fd,
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message =
+      data.detail ||
+      (Array.isArray(data.file) ? data.file[0] : data.file) ||
+      'Failed to upload image.';
+    throw new Error(message);
+  }
+  return response.json();
+};
+
+export const deleteImage = async (
+  imageId: string,
+): Promise<void> => {
+  const response = await authenticatedFetch(
+    `${API_BASE_URL}/api/v1/images/${imageId}/`,
+    { method: 'DELETE' },
+  );
+  if (!response.ok && response.status !== 204) {
+    throw new Error('Failed to delete image.');
+  }
+};
+
+export const fetchCommentImages = async (
+  noteId: string,
+  commentId: string,
+): Promise<CommentImage[]> => {
+  const response = await publicFetch(
+    `${API_BASE_URL}/api/v1/notes/${noteId}/comments/${commentId}/images/`,
+  );
+  if (!response.ok) {
+    throw new Error('Failed to fetch images.');
+  }
+  return response.json();
 };
 
 export const fetchCommentCounts = async (params: {

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -114,6 +114,9 @@ const CommentForm = ({
       urlsRef.current = [];
       setStaged([]);
       setStagedUrls([]);
+    } catch {
+      // caller already surfaced the error via notification;
+      // keep form state so the user can retry
     } finally {
       setLocalSubmitting(false);
     }

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -101,8 +101,8 @@ const CommentForm = ({
   };
 
   const handleSubmit = async () => {
-    if (!value.trim()) {
-      setError('Comment cannot be empty.');
+    if (!value.trim() && staged.length === 0) {
+      setError('Add text or attach an image.');
       return;
     }
     setError(null);

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -1,14 +1,35 @@
-import { useState } from 'react';
-import { Group, Textarea, Button } from '@mantine/core';
+import { useState, useEffect, useRef } from 'react';
+import {
+  Group,
+  Textarea,
+  Button,
+  FileButton,
+  Box,
+  Text,
+  ActionIcon,
+} from '@mantine/core';
+import { IconX, IconPhoto } from '@tabler/icons-react';
+import { CommentImage } from '../types';
+
+const ALLOWED_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+const MAX_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGES = 5;
 
 interface CommentFormProps {
   initialValue?: string;
   submitLabel?: string;
   placeholder?: string;
   autoFocus?: boolean;
-  onSubmit: (content: string) => Promise<void>;
+  onSubmit: (content: string, files: File[]) => Promise<void>;
   onCancel?: () => void;
   submitting?: boolean;
+  existingImages?: CommentImage[];
+  onDeleteImage?: (imageId: string) => Promise<void>;
 }
 
 const CommentForm = ({
@@ -19,12 +40,65 @@ const CommentForm = ({
   onSubmit,
   onCancel,
   submitting = false,
+  existingImages = [],
+  onDeleteImage,
 }: CommentFormProps) => {
   const [value, setValue] = useState(initialValue);
   const [error, setError] = useState<string | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
   const [localSubmitting, setLocalSubmitting] = useState(false);
+  const [staged, setStaged] = useState<File[]>([]);
+  const [stagedUrls, setStagedUrls] = useState<string[]>([]);
+  const urlsRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    return () => {
+      urlsRef.current.forEach((u) => URL.revokeObjectURL(u));
+    };
+  }, []);
 
   const isDisabled = submitting || localSubmitting;
+  const totalAttached = existingImages.length + staged.length;
+
+  const handleFileSelect = (files: File[]) => {
+    setFileError(null);
+    const validFiles: File[] = [];
+    const newUrls: string[] = [];
+    for (const file of files) {
+      if (!ALLOWED_TYPES.includes(file.type)) {
+        setFileError(`Unsupported file type: ${file.name}`);
+        continue;
+      }
+      if (file.size > MAX_BYTES) {
+        setFileError(`File too large (max 10 MiB): ${file.name}`);
+        continue;
+      }
+      if (
+        existingImages.length + staged.length + validFiles.length >=
+        MAX_IMAGES
+      ) {
+        setFileError('Maximum 5 images per comment.');
+        break;
+      }
+      const url = URL.createObjectURL(file);
+      urlsRef.current.push(url);
+      validFiles.push(file);
+      newUrls.push(url);
+    }
+    if (validFiles.length > 0) {
+      setStaged((prev) => [...prev, ...validFiles]);
+      setStagedUrls((prev) => [...prev, ...newUrls]);
+    }
+  };
+
+  const removeStaged = (idx: number) => {
+    URL.revokeObjectURL(stagedUrls[idx]);
+    urlsRef.current = urlsRef.current.filter(
+      (u) => u !== stagedUrls[idx]
+    );
+    setStaged((prev) => prev.filter((_, i) => i !== idx));
+    setStagedUrls((prev) => prev.filter((_, i) => i !== idx));
+  };
 
   const handleSubmit = async () => {
     if (!value.trim()) {
@@ -34,8 +108,12 @@ const CommentForm = ({
     setError(null);
     setLocalSubmitting(true);
     try {
-      await onSubmit(value.trim());
+      await onSubmit(value.trim(), staged);
       setValue('');
+      staged.forEach((_, i) => URL.revokeObjectURL(stagedUrls[i]));
+      urlsRef.current = [];
+      setStaged([]);
+      setStagedUrls([]);
     } finally {
       setLocalSubmitting(false);
     }
@@ -54,6 +132,76 @@ const CommentForm = ({
         disabled={isDisabled}
         mb={6}
       />
+
+      {(existingImages.length > 0 || staged.length > 0) && (
+        <Group spacing={6} mb={6} align="flex-start">
+          {existingImages.map((img) => (
+            <Box
+              key={img.id}
+              style={{ position: 'relative', display: 'inline-block' }}
+            >
+              <img
+                src={img.signed_url}
+                alt="attached"
+                style={{
+                  height: 56,
+                  width: 56,
+                  objectFit: 'cover',
+                  borderRadius: 4,
+                  display: 'block',
+                }}
+              />
+              {onDeleteImage && (
+                <ActionIcon
+                  size="xs"
+                  color="red"
+                  variant="filled"
+                  style={{ position: 'absolute', top: 2, right: 2 }}
+                  onClick={() => onDeleteImage(img.id)}
+                  aria-label={`Remove image ${img.id}`}
+                >
+                  <IconX size={10} />
+                </ActionIcon>
+              )}
+            </Box>
+          ))}
+          {staged.map((file, idx) => (
+            <Box
+              key={idx}
+              style={{ position: 'relative', display: 'inline-block' }}
+            >
+              <img
+                src={stagedUrls[idx]}
+                alt={file.name}
+                style={{
+                  height: 56,
+                  width: 56,
+                  objectFit: 'cover',
+                  borderRadius: 4,
+                  display: 'block',
+                }}
+              />
+              <ActionIcon
+                size="xs"
+                color="red"
+                variant="filled"
+                style={{ position: 'absolute', top: 2, right: 2 }}
+                onClick={() => removeStaged(idx)}
+                aria-label={`Remove staged image ${idx}`}
+              >
+                <IconX size={10} />
+              </ActionIcon>
+            </Box>
+          ))}
+        </Group>
+      )}
+
+      {fileError && (
+        <Text size="xs" color="red" mb={4}>
+          {fileError}
+        </Text>
+      )}
+
       <Group spacing="xs">
         <Button
           size="xs"
@@ -73,6 +221,25 @@ const CommentForm = ({
             Cancel
           </Button>
         )}
+        <FileButton
+          onChange={handleFileSelect}
+          accept={ALLOWED_TYPES.join(',')}
+          multiple
+          disabled={isDisabled || totalAttached >= MAX_IMAGES}
+        >
+          {(props) => (
+            <Button
+              {...props}
+              size="xs"
+              variant="subtle"
+              leftIcon={<IconPhoto size={14} />}
+              disabled={isDisabled || totalAttached >= MAX_IMAGES}
+              aria-label="Attach images"
+            >
+              {totalAttached > 0 ? `${totalAttached}/5` : 'Images'}
+            </Button>
+          )}
+        </FileButton>
       </Group>
     </div>
   );

--- a/src/components/CommentNode.tsx
+++ b/src/components/CommentNode.tsx
@@ -1,7 +1,15 @@
 import { useState } from 'react';
-import { Box, Text, Stack } from '@mantine/core';
+import {
+  Box,
+  Text,
+  Stack,
+  SimpleGrid,
+  ActionIcon,
+  Modal,
+} from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
-import { Comment } from '../types';
+import { IconX } from '@tabler/icons-react';
+import { Comment, CommentImage } from '../types';
 import CommentForm from './CommentForm';
 import CommentActions from './CommentActions';
 
@@ -12,10 +20,20 @@ interface CommentNodeProps {
   isAuthenticated: boolean;
   onReply: (
     parentId: string,
-    content: string
+    content: string,
+    files: File[]
   ) => Promise<void>;
-  onUpdate: (id: string, content: string) => Promise<void>;
+  onUpdate: (
+    id: string,
+    content: string,
+    files: File[]
+  ) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
+  onDeleteImage?: (
+    commentId: string,
+    imageId: string
+  ) => Promise<void>;
+  onRequestRefresh?: () => void;
 }
 
 const MAX_DEPTH = 6;
@@ -28,9 +46,13 @@ const CommentNode = ({
   onReply,
   onUpdate,
   onDelete,
+  onDeleteImage,
+  onRequestRefresh,
 }: CommentNodeProps) => {
   const [replyOpen, setReplyOpen] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [lightboxImage, setLightboxImage] =
+    useState<CommentImage | null>(null);
 
   const isAuthor =
     !!currentUsername &&
@@ -56,13 +78,19 @@ const CommentNode = ({
     }
   };
 
-  const handleReplySubmit = async (content: string) => {
-    await onReply(comment.id, content);
+  const handleReplySubmit = async (
+    content: string,
+    files: File[]
+  ) => {
+    await onReply(comment.id, content, files);
     setReplyOpen(false);
   };
 
-  const handleEditSubmit = async (content: string) => {
-    await onUpdate(comment.id, content);
+  const handleEditSubmit = async (
+    content: string,
+    files: File[]
+  ) => {
+    await onUpdate(comment.id, content, files);
     setEditing(false);
   };
 
@@ -75,6 +103,8 @@ const CommentNode = ({
       onConfirm: () => onDelete(comment.id),
     });
   };
+
+  const images = comment.images ?? [];
 
   return (
     <Box
@@ -108,9 +138,73 @@ const CommentNode = ({
               autoFocus
               onSubmit={handleEditSubmit}
               onCancel={() => setEditing(false)}
+              existingImages={images}
+              onDeleteImage={
+                onDeleteImage
+                  ? (imageId) =>
+                      onDeleteImage(comment.id, imageId)
+                  : undefined
+              }
             />
           ) : (
-            <Text size="sm">{comment.content}</Text>
+            <>
+              <Text size="sm">{comment.content}</Text>
+
+              {images.length > 0 && (
+                <SimpleGrid
+                  cols={3}
+                  spacing={4}
+                  breakpoints={[
+                    { maxWidth: 'xs', cols: 2 },
+                  ]}
+                  mt={4}
+                >
+                  {images.map((img) => (
+                    <Box
+                      key={img.id}
+                      style={{
+                        position: 'relative',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <img
+                        src={img.signed_url}
+                        loading="lazy"
+                        alt="comment attachment"
+                        onError={onRequestRefresh}
+                        onClick={() => setLightboxImage(img)}
+                        style={{
+                          width: '100%',
+                          maxHeight: 200,
+                          objectFit: 'cover',
+                          borderRadius: 4,
+                          display: 'block',
+                        }}
+                      />
+                      {isAuthor && onDeleteImage && (
+                        <ActionIcon
+                          size="xs"
+                          color="red"
+                          variant="filled"
+                          style={{
+                            position: 'absolute',
+                            top: 4,
+                            right: 4,
+                          }}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDeleteImage(comment.id, img.id);
+                          }}
+                          aria-label={`Delete image ${img.id}`}
+                        >
+                          <IconX size={10} />
+                        </ActionIcon>
+                      )}
+                    </Box>
+                  ))}
+                </SimpleGrid>
+              )}
+            </>
           )}
 
           {!editing && (
@@ -150,10 +244,28 @@ const CommentNode = ({
               onReply={onReply}
               onUpdate={onUpdate}
               onDelete={onDelete}
+              onDeleteImage={onDeleteImage}
+              onRequestRefresh={onRequestRefresh}
             />
           ))}
         </Stack>
       )}
+
+      <Modal
+        opened={lightboxImage !== null}
+        onClose={() => setLightboxImage(null)}
+        size="xl"
+        title="Image"
+        padding="xs"
+      >
+        {lightboxImage && (
+          <img
+            src={lightboxImage.signed_url}
+            alt="full size"
+            style={{ width: '100%', height: 'auto' }}
+          />
+        )}
+      </Modal>
     </Box>
   );
 };

--- a/src/components/CommentNode.tsx
+++ b/src/components/CommentNode.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconX } from '@tabler/icons-react';
-import { Comment, CommentImage } from '../types';
+import { Comment } from '../types';
 import CommentForm from './CommentForm';
 import CommentActions from './CommentActions';
 
@@ -51,8 +51,8 @@ const CommentNode = ({
 }: CommentNodeProps) => {
   const [replyOpen, setReplyOpen] = useState(false);
   const [editing, setEditing] = useState(false);
-  const [lightboxImage, setLightboxImage] =
-    useState<CommentImage | null>(null);
+  const [lightboxImageId, setLightboxImageId] =
+    useState<string | null>(null);
 
   const isAuthor =
     !!currentUsername &&
@@ -105,6 +105,8 @@ const CommentNode = ({
   };
 
   const images = comment.images ?? [];
+  const lightboxImage =
+    images.find((img) => img.id === lightboxImageId) ?? null;
 
   return (
     <Box
@@ -172,7 +174,7 @@ const CommentNode = ({
                         loading="lazy"
                         alt="comment attachment"
                         onError={onRequestRefresh}
-                        onClick={() => setLightboxImage(img)}
+                        onClick={() => setLightboxImageId(img.id)}
                         style={{
                           width: '100%',
                           maxHeight: 200,
@@ -252,8 +254,8 @@ const CommentNode = ({
       )}
 
       <Modal
-        opened={lightboxImage !== null}
-        onClose={() => setLightboxImage(null)}
+        opened={lightboxImageId !== null}
+        onClose={() => setLightboxImageId(null)}
         size="xl"
         title="Image"
         padding="xs"
@@ -262,6 +264,7 @@ const CommentNode = ({
           <img
             src={lightboxImage.signed_url}
             alt="full size"
+            onError={onRequestRefresh}
             style={{ width: '100%', height: 'auto' }}
           />
         )}

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -30,6 +30,7 @@ const normalize = (
 ): Comment[] =>
   (nodes ?? []).map((c) => ({
     ...c,
+    images: c.images ?? [],
     replies: normalize(c.replies),
   }));
 

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -15,6 +15,8 @@ import {
   createComment,
   updateComment,
   deleteComment,
+  uploadCommentImage,
+  deleteImage,
 } from '../api';
 import {
   insertReply,
@@ -109,7 +111,8 @@ const CommentThread = ({
 
   const handleCreate = async (
     parentId: string | null,
-    content: string
+    content: string,
+    files: File[] = []
   ) => {
     setSubmitting(true);
     try {
@@ -118,12 +121,33 @@ const CommentThread = ({
         content,
         parentId
       );
+      const uploadedImages = [];
+      for (const file of files) {
+        try {
+          const img = await uploadCommentImage(
+            noteId,
+            newComment.id,
+            file
+          );
+          uploadedImages.push(img);
+        } catch (err: unknown) {
+          const msg =
+            err instanceof Error
+              ? err.message
+              : 'Failed to upload image.';
+          showNotification({
+            color: 'red',
+            title: 'Upload failed',
+            message: msg,
+          });
+        }
+      }
+      const normalizedNew = {
+        ...normalize([newComment])[0],
+        images: uploadedImages,
+      };
       setComments((prev) =>
-        insertReply(
-          prev,
-          parentId,
-          normalize([newComment])[0]
-        )
+        insertReply(prev, parentId, normalizedNew)
       );
       onCountChange?.(1);
       silentLoad();
@@ -138,11 +162,40 @@ const CommentThread = ({
     }
   };
 
-  const handleUpdate = async (id: string, content: string) => {
+  const handleUpdate = async (
+    id: string,
+    content: string,
+    files: File[] = []
+  ) => {
     try {
       const updated = await updateComment(noteId, id, content);
+      const existingImages = updated.images ?? [];
+      const newImages = [...existingImages];
+      for (const file of files) {
+        try {
+          const img = await uploadCommentImage(
+            noteId,
+            id,
+            file
+          );
+          newImages.push(img);
+        } catch (err: unknown) {
+          const msg =
+            err instanceof Error
+              ? err.message
+              : 'Failed to upload image.';
+          showNotification({
+            color: 'red',
+            title: 'Upload failed',
+            message: msg,
+          });
+        }
+      }
       setComments((prev) =>
-        updateNode(prev, id, () => normalize([updated])[0])
+        updateNode(prev, id, () => ({
+          ...normalize([updated])[0],
+          images: newImages,
+        }))
       );
       silentLoad();
     } catch {
@@ -150,6 +203,29 @@ const CommentThread = ({
         color: 'red',
         title: 'Error',
         message: 'Failed to update comment.',
+      });
+    }
+  };
+
+  const handleDeleteImage = async (
+    commentId: string,
+    imageId: string
+  ) => {
+    try {
+      await deleteImage(imageId);
+      setComments((prev) =>
+        updateNode(prev, commentId, (n) => ({
+          ...n,
+          images: (n.images ?? []).filter(
+            (i) => i.id !== imageId
+          ),
+        }))
+      );
+    } catch {
+      showNotification({
+        color: 'red',
+        title: 'Error',
+        message: 'Failed to delete image.',
       });
     }
   };
@@ -227,11 +303,13 @@ const CommentThread = ({
               depth={0}
               currentUsername={currentUsername}
               isAuthenticated={isAuthenticated}
-              onReply={(parentId, content) =>
-                handleCreate(parentId, content)
+              onReply={(parentId, content, files) =>
+                handleCreate(parentId, content, files)
               }
               onUpdate={handleUpdate}
               onDelete={handleDelete}
+              onDeleteImage={handleDeleteImage}
+              onRequestRefresh={silentLoad}
             />
           ))}
         </Stack>
@@ -242,7 +320,9 @@ const CommentThread = ({
           placeholder="Add a comment…"
           submitLabel="Post"
           submitting={submitting}
-          onSubmit={(content) => handleCreate(null, content)}
+          onSubmit={(content, files) =>
+            handleCreate(null, content, files)
+          }
         />
       )}
     </Stack>

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -151,12 +151,13 @@ const CommentThread = ({
       );
       onCountChange?.(1);
       silentLoad();
-    } catch {
+    } catch (err) {
       showNotification({
         color: 'red',
         title: 'Error',
         message: 'Failed to post comment.',
       });
+      throw err;
     } finally {
       setSubmitting(false);
     }
@@ -198,12 +199,13 @@ const CommentThread = ({
         }))
       );
       silentLoad();
-    } catch {
+    } catch (err) {
       showNotification({
         color: 'red',
         title: 'Error',
         message: 'Failed to update comment.',
       });
+      throw err;
     }
   };
 

--- a/src/components/__tests__/CommentForm.test.tsx
+++ b/src/components/__tests__/CommentForm.test.tsx
@@ -73,8 +73,34 @@ describe('CommentForm', () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByText('Comment cannot be empty.')
+        screen.getByText('Add text or attach an image.')
       ).toBeInTheDocument();
+    });
+  });
+
+  it('submits with only staged images and no text', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <CommentForm onSubmit={onSubmit} />
+    );
+
+    const input = document
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(
+      ['x'], 'photo.png', { type: 'image/png' }
+    );
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Post' })
+    );
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('', [file]);
     });
   });
 

--- a/src/components/__tests__/CommentForm.test.tsx
+++ b/src/components/__tests__/CommentForm.test.tsx
@@ -7,6 +7,16 @@ import {
 import { describe, it, expect, vi } from 'vitest';
 import CommentForm from '../CommentForm';
 import { renderWithProviders } from '../../__tests__/helpers';
+import { CommentImage } from '../../types';
+
+const makeImage = (id: string): CommentImage => ({
+  id,
+  signed_url: `https://example.com/${id}.png`,
+  content_type: 'image/png',
+  size_bytes: 1024,
+  uploaded_by: 1,
+  created_at: '2024-01-01T00:00:00Z',
+});
 
 describe('CommentForm', () => {
   it('renders textarea and submit button', () => {
@@ -68,7 +78,7 @@ describe('CommentForm', () => {
     });
   });
 
-  it('calls onSubmit with trimmed content', async () => {
+  it('calls onSubmit with trimmed content and empty files', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(
       <CommentForm onSubmit={onSubmit} />
@@ -80,7 +90,10 @@ describe('CommentForm', () => {
       screen.getByRole('button', { name: 'Post' })
     );
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith('hello world');
+      expect(onSubmit).toHaveBeenCalledWith(
+        'hello world',
+        []
+      );
     });
   });
 
@@ -109,5 +122,110 @@ describe('CommentForm', () => {
       (screen.getByRole('textbox') as HTMLTextAreaElement)
         .value
     ).toBe('existing text');
+  });
+
+  it('selecting a valid file stages a thumbnail', async () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    const input = document
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['x'], 'photo.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('img[alt="photo.png"]').length
+      ).toBe(1);
+    });
+  });
+
+  it('rejects a file with wrong MIME type', async () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    const input = document
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(
+      ['x'],
+      'doc.pdf',
+      { type: 'application/pdf' }
+    );
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Unsupported file type/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('rejects a file that exceeds 10 MiB', async () => {
+    renderWithProviders(
+      <CommentForm onSubmit={vi.fn()} />
+    );
+    const input = document
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    const bigFile = new File(
+      [new ArrayBuffer(11 * 1024 * 1024)],
+      'big.png',
+      { type: 'image/png' }
+    );
+    Object.defineProperty(input, 'files', {
+      value: [bigFile],
+      configurable: true,
+    });
+    fireEvent.change(input);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/File too large/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('enforces the 5-image cap with existingImages', async () => {
+    const existing = [1, 2, 3, 4, 5].map((i) =>
+      makeImage(`img-${i}`)
+    );
+    renderWithProviders(
+      <CommentForm
+        onSubmit={vi.fn()}
+        existingImages={existing}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Attach images' })
+    ).toBeDisabled();
+  });
+
+  it('calls onSubmit with staged files', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <CommentForm onSubmit={onSubmit} />
+    );
+
+    const input = document
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['x'], 'test.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'hello' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith('hello', [file]);
+    });
   });
 });

--- a/src/components/__tests__/CommentNode.test.tsx
+++ b/src/components/__tests__/CommentNode.test.tsx
@@ -3,7 +3,16 @@ import { screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import CommentNode from '../CommentNode';
 import { renderWithProviders } from '../../__tests__/helpers';
-import { Comment } from '../../api';
+import { Comment, CommentImage } from '../../types';
+
+const makeImage = (id: string): CommentImage => ({
+  id,
+  signed_url: `https://example.com/${id}.png`,
+  content_type: 'image/png',
+  size_bytes: 1024,
+  uploaded_by: 1,
+  created_at: '2024-01-01T00:00:00Z',
+});
 
 const makeComment = (overrides: Partial<Comment> = {}): Comment => ({
   id: 'c1',
@@ -14,6 +23,7 @@ const makeComment = (overrides: Partial<Comment> = {}): Comment => ({
   timestamp: '2024-01-01T00:00:00Z',
   is_deleted: false,
   replies: [],
+  images: [],
   ...overrides,
 });
 
@@ -24,6 +34,7 @@ const defaultProps = {
   onReply: vi.fn().mockResolvedValue(undefined),
   onUpdate: vi.fn().mockResolvedValue(undefined),
   onDelete: vi.fn().mockResolvedValue(undefined),
+  onDeleteImage: vi.fn().mockResolvedValue(undefined),
 };
 
 describe('CommentNode', () => {
@@ -142,5 +153,43 @@ describe('CommentNode', () => {
     expect(
       screen.getByText('A nested reply')
     ).toBeInTheDocument();
+  });
+
+  it('renders image thumbnails when comment has images', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ images: [makeImage('img-1')] })}
+        {...defaultProps}
+      />
+    );
+    expect(
+      document.querySelector('img[alt="comment attachment"]')
+    ).toBeInTheDocument();
+  });
+
+  it('shows delete affordance on each image for the author', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ images: [makeImage('img-1')] })}
+        {...defaultProps}
+        currentUsername="alice"
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Delete image img-1' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides delete affordance on images for non-author', () => {
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ images: [makeImage('img-1')] })}
+        {...defaultProps}
+        currentUsername="bob"
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Delete image img-1' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/CommentNode.test.tsx
+++ b/src/components/__tests__/CommentNode.test.tsx
@@ -192,4 +192,63 @@ describe('CommentNode', () => {
       screen.queryByRole('button', { name: 'Delete image img-1' })
     ).not.toBeInTheDocument();
   });
+
+  it('lightbox shows fresh signed URL after comment prop update', () => {
+    const img1 = makeImage('img-1');
+    const { rerender } = renderWithProviders(
+      <CommentNode
+        comment={makeComment({ images: [img1] })}
+        {...defaultProps}
+      />
+    );
+
+    fireEvent.click(
+      document.querySelector(
+        'img[alt="comment attachment"]'
+      )!
+    );
+
+    const lightboxImg = screen.getByAltText(
+      'full size'
+    ) as HTMLImageElement;
+    expect(lightboxImg.src).toBe(
+      'https://example.com/img-1.png'
+    );
+
+    const refreshedImg = {
+      ...img1,
+      signed_url: 'https://example.com/img-1-refreshed.png',
+    };
+    rerender(
+      <CommentNode
+        comment={makeComment({ images: [refreshedImg] })}
+        {...defaultProps}
+      />
+    );
+
+    expect(lightboxImg.src).toBe(
+      'https://example.com/img-1-refreshed.png'
+    );
+  });
+
+  it('lightbox img onError calls onRequestRefresh', () => {
+    const onRequestRefresh = vi.fn();
+    renderWithProviders(
+      <CommentNode
+        comment={makeComment({ images: [makeImage('img-1')] })}
+        {...defaultProps}
+        onRequestRefresh={onRequestRefresh}
+      />
+    );
+
+    fireEvent.click(
+      document.querySelector(
+        'img[alt="comment attachment"]'
+      )!
+    );
+
+    fireEvent.error(screen.getByAltText('full size'));
+
+    expect(onRequestRefresh).toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/CommentThread.test.tsx
+++ b/src/components/__tests__/CommentThread.test.tsx
@@ -299,6 +299,50 @@ describe('CommentThread', () => {
     });
   });
 
+  it('retains form content when createComment fails', async () => {
+    server.use(
+      http.post(
+        `${API_URL}/notes/${NOTE_ID}/comments/`,
+        () => HttpResponse.error()
+      )
+    );
+
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Add a comment…')
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Add a comment…'),
+      { target: { value: 'Keep me on failure' } }
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Post' })
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByPlaceholderText(
+          'Add a comment…'
+        ) as HTMLTextAreaElement).value
+      ).toBe('Keep me on failure');
+    });
+  });
+
   it('calls image upload endpoint after creating comment with a file', async () => {
     let uploadCalled = false;
     server.use(

--- a/src/components/__tests__/CommentThread.test.tsx
+++ b/src/components/__tests__/CommentThread.test.tsx
@@ -238,4 +238,126 @@ describe('CommentThread', () => {
       expect(onCountChange).toHaveBeenCalledWith(1);
     });
   });
+
+  it('removes image from comment after delete-image', async () => {
+    server.use(
+      http.get(
+        `${API_URL}/notes/${NOTE_ID}/comments/`,
+        () =>
+          HttpResponse.json([
+            {
+              id: 'comment-1',
+              author: { id: 1, username: 'testuser' },
+              note_id: NOTE_ID,
+              parent_comment: null,
+              content: 'Test comment',
+              timestamp: new Date().toISOString(),
+              is_deleted: false,
+              replies: [],
+              images: [
+                {
+                  id: 'img-1',
+                  signed_url: 'https://example.com/img-1.png',
+                  content_type: 'image/png',
+                  size_bytes: 1024,
+                  uploaded_by: 1,
+                  created_at: new Date().toISOString(),
+                },
+              ],
+            },
+          ])
+      )
+    );
+
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('img[alt="comment attachment"]')
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete image img-1' })
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('img[alt="comment attachment"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls image upload endpoint after creating comment with a file', async () => {
+    let uploadCalled = false;
+    server.use(
+      http.post(
+        `${API_URL}/notes/${NOTE_ID}/comments/:commentId/images/`,
+        async () => {
+          uploadCalled = true;
+          return HttpResponse.json(
+            {
+              id: 'img-new',
+              signed_url: 'https://example.com/img-new.png',
+              content_type: 'image/png',
+              size_bytes: 100,
+              uploaded_by: 1,
+              created_at: new Date().toISOString(),
+            },
+            { status: 201 }
+          );
+        }
+      )
+    );
+
+    renderWithProviders(
+      <CommentThread noteId={NOTE_ID} />,
+      {
+        stores: {
+          auth: {
+            isAuthenticated: true,
+            user: { username: 'testuser' },
+            token: 'fake-token',
+          },
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('Add a comment…')
+      ).toBeInTheDocument();
+    });
+
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(['x'], 'test.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Add a comment…'),
+      { target: { value: 'Comment with image' } }
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => {
+      expect(uploadCalled).toBe(true);
+    });
+  });
 });

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -87,6 +87,7 @@ export const handlers = [
         timestamp: new Date().toISOString(),
         is_deleted: false,
         replies: [],
+        images: [],
       },
     ]);
   }),
@@ -104,6 +105,7 @@ export const handlers = [
         timestamp: new Date().toISOString(),
         is_deleted: false,
         replies: [],
+        images: [],
       }, { status: 201 });
     }
   ),
@@ -121,6 +123,7 @@ export const handlers = [
         timestamp: new Date().toISOString(),
         is_deleted: false,
         replies: [],
+        images: [],
       });
     }
   ),
@@ -129,6 +132,48 @@ export const handlers = [
     `${COMMENT_BASE}/notes/:noteId/comments/:commentId/`,
     () => {
       return new HttpResponse(null, { status: 204 });
+    }
+  ),
+
+  // --- Comment Images ---
+  http.post(
+    `${COMMENT_BASE}/notes/:noteId/comments/:commentId/images/`,
+    async ({ params }) => {
+      return HttpResponse.json({
+        id: 'img-1',
+        signed_url: 'https://example.com/img-1.png',
+        content_type: 'image/png',
+        size_bytes: 1024,
+        uploaded_by: 1,
+        comment: params.commentId,
+        note: params.noteId,
+        created_at: new Date().toISOString(),
+      }, { status: 201 });
+    }
+  ),
+
+  http.delete(
+    `${COMMENT_BASE}/images/:imageId/`,
+    () => {
+      return new HttpResponse(null, { status: 204 });
+    }
+  ),
+
+  http.get(
+    `${COMMENT_BASE}/notes/:noteId/comments/:commentId/images/`,
+    ({ params }) => {
+      return HttpResponse.json([
+        {
+          id: 'img-1',
+          signed_url: 'https://example.com/img-1.png',
+          content_type: 'image/png',
+          size_bytes: 1024,
+          uploaded_by: 1,
+          comment: params.commentId,
+          note: params.noteId,
+          created_at: new Date().toISOString(),
+        },
+      ]);
     }
   ),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,15 @@ export interface CommentAuthor {
   username: string;
 }
 
+export interface CommentImage {
+  id: string;
+  signed_url: string;
+  content_type: string;
+  size_bytes: number;
+  uploaded_by: number;
+  created_at: string;
+}
+
 export interface Comment {
   id: string;
   author: CommentAuthor;
@@ -52,6 +61,7 @@ export interface Comment {
   timestamp: string;
   is_deleted: boolean;
   replies: Comment[] | undefined;
+  images: CommentImage[];
 }
 
 export type CommentCounts = Record<string, number>;

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -114,6 +114,60 @@ export const authenticatedFetch = async (
 };
 
 /**
+ * Authenticated multipart upload.
+ * Sets only the Authorization header; lets the browser generate
+ * the multipart Content-Type with its boundary.
+ * Mirrors authenticatedFetch's 401 (logout + notification) and
+ * 403 (throw permission error) handling.
+ */
+export const authenticatedUpload = async (
+  url: string,
+  formData: FormData,
+  retries = 1,
+): Promise<Response> => {
+  const token = useAuthStore.getState().token;
+  const headers: HeadersInit = {};
+  if (token) headers['Authorization'] = `Token ${token}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: formData,
+    });
+
+    if (response.status === 401) {
+      console.warn('401 Unauthorized - logging out user');
+      useAuthStore.getState().logout();
+      showNotification({
+        title: 'Session Expired',
+        message: 'Your session has expired. Please log in again.',
+        color: 'orange',
+        autoClose: 5000,
+      });
+      throw new Error('Session expired. Please log in again.');
+    }
+
+    if (response.status === 403) {
+      throw new Error(
+        'You do not have permission to access this resource.',
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (retries > 0 && error instanceof TypeError) {
+      console.warn(
+        'Network error (authenticatedUpload), retrying...',
+        error,
+      );
+      return authenticatedUpload(url, formData, retries - 1);
+    }
+    throw error;
+  }
+};
+
+/**
  * Helper to check if user is authenticated
  * @returns boolean
  */


### PR DESCRIPTION
## Summary

Implements image attachments in the comment thread on the `reactive-bible` frontend, consuming the backend API shipped in `bible_research` commits `cb1698c` and `0f0e30b`.

## Changes

### Types & API client (`src/types.ts`, `src/utils/apiClient.ts`, `src/api.tsx`)
- New `CommentImage` interface; `Comment.images: CommentImage[]` (non-optional, always present)
- `authenticatedUpload` — multipart helper that omits `Content-Type` so the browser generates the multipart boundary; mirrors `authenticatedFetch` 401/403 handling
- `uploadCommentImage`, `deleteImage`, `fetchCommentImages` API functions

### MSW handlers (`src/mocks/handlers.ts`)
- All comment fixtures now include `images: []`
- New handlers: `POST /notes/:noteId/comments/:commentId/images/`, `DELETE /images/:imageId/`, `GET /notes/:noteId/comments/:commentId/images/`

### `CommentForm` (`src/components/CommentForm.tsx`)
- `onSubmit` signature changed to `(content: string, files: File[]) => Promise<void>`
- `FileButton` (multi-select, image MIME types only) with staged thumbnail strip
- Client-side validation: MIME type allowlist, 10 MiB cap, 5-image-per-comment cap (counts existing + staged)
- `existingImages` prop — shows currently attached images with per-image delete button in edit mode
- Object URLs revoked on removal and on unmount

### `CommentNode` (`src/components/CommentNode.tsx`)
- `SimpleGrid` thumbnail gallery below comment text (hidden when `images` is empty)
- `Modal` lightbox on thumbnail click
- Author-only delete overlay (`ActionIcon`) per thumbnail, calling `onDeleteImage`
- New props: `onDeleteImage?(commentId, imageId)`, `onRequestRefresh?()`; both passed recursively to reply nodes
- `<img onError={onRequestRefresh}>` triggers `silentLoad` on signed-URL expiry

### `CommentThread` (`src/components/CommentThread.tsx`)
- `normalize` defaults `images` to `[]` for safety
- `handleCreate` — two-phase submit: `createComment` → per-file `uploadCommentImage`; per-file upload failures surface a toast without rolling back the comment
- `handleUpdate` — uploads new files after patching comment text
- `handleDeleteImage` — calls `deleteImage` then removes the image from tree state via `updateNode`
- `silentLoad` passed as `onRequestRefresh`; `handleDeleteImage` passed as `onDeleteImage`

## Tests

| File | New tests |
|------|-----------|
| `CommentForm.test.tsx` | file staging thumbnail; wrong MIME type rejected; oversized file rejected; 5-image cap enforced; `onSubmit` called with files |
| `CommentNode.test.tsx` | gallery renders; author sees delete affordance; non-author does not |
| `CommentThread.test.tsx` | delete-image removes image from state; create-with-file calls upload endpoint |

Fixed `URL.createObjectURL` / `URL.revokeObjectURL` mocks in `helpers.tsx` — happy-dom does not accept `File` as a `Blob` subclass.

## Linked plan

`reactive-bible/COMMENT_IMAGES_PLAN.md`
